### PR TITLE
Context init parameter to append to relative_url_root after the context path

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ web.xml.
   Merb application files. Defaults to `/WEB-INF`.
 - `rails.env`: Specify the Rails environment to run. Defaults
   to 'production'.
+- `rails.relative_url_append`: Specify a path to be appended to the 
+  ActionController::Base.relative_url_root after the context path. Useful
+  for running a rails app from the same war as an existing app, under
+  a sub-path of the main servlet context root.
 - `merb.environment`: Specify the merb environment to run. Defaults to
   `production`.
 

--- a/src/main/ruby/jruby/rack/rails.rb
+++ b/src/main/ruby/jruby/rack/rails.rb
@@ -30,7 +30,8 @@ module JRuby::Rack
     end
 
     def setup_relative_url_root
-      relative_url_root = @rack_context.getContextPath
+      relative_url_append = @rack_context.getInitParameter('rails.relative_url_append') || ''
+      relative_url_root = @rack_context.getContextPath + relative_url_append
       if relative_url_root && !relative_url_root.empty? && relative_url_root != '/'
         ENV['RAILS_RELATIVE_URL_ROOT'] = relative_url_root
       end

--- a/src/spec/ruby/jruby/rack/rails_spec.rb
+++ b/src/spec/ruby/jruby/rack/rails_spec.rb
@@ -49,6 +49,13 @@ describe JRuby::Rack::RailsBooter do
     ENV['RAILS_RELATIVE_URL_ROOT'].should == '/myapp'
   end
 
+  it "should append to RAILS_RELATIVE_URL_ROOT if 'rails.relative_url_append' is set" do
+    @rack_context.should_receive(:getContextPath).and_return '/myapp'
+    @rack_context.should_receive(:getInitParameter).with("rails.relative_url_append").and_return "/blah"
+    create_booter(JRuby::Rack::RailsBooter).boot!
+    ENV['RAILS_RELATIVE_URL_ROOT'].should == '/myapp/blah'
+  end
+
   it "should determine the public html root from the 'public.root' init parameter" do
     @rack_context.should_receive(:getInitParameter).with("public.root").and_return "/blah"
     @rack_context.should_receive(:getRealPath).with("/blah").and_return "."


### PR DESCRIPTION
Hi Nick!

We are using jruby-rack over here to deploy one of our applications, and we had a use case that the base configuration options couldn't account for. Specifically, we are deploying some rails stuff alongside an existing JSF application, and we needed to have both packaged in the same war file. The rails portion of the app is hosted under a sub-url of the base context (e.g. if the app is deployed at "/myapp", then the rails routes are reachable from "/myapp/r".)

To make this work, we needed to append the sub-path to the relative_url_root, but jruby-rack already helpfully sets that for you, and it happens after configuration is loaded, overwriting any custom setting of the relative_url_root from your environment file.

My solution is pretty simple. We just added a context init parameter (called rails.relative_url_append) that, if set, gets tacked on to the end of the relative_url_root, after the servlet context path.

I can't imagine that we're the only people who will ever have this problem, so I've made the changes available if you'd like to include them.

Please let me know if you have any questions.

Thanks!

Ben Rosenblum
