### PR TITLE
Make line numbers in evaluated config.ru jive with the actual config.ru file

### DIFF
--- a/src/main/java/org/jruby/rack/DefaultRackApplicationFactory.java
+++ b/src/main/java/org/jruby/rack/DefaultRackApplicationFactory.java
@@ -161,7 +161,7 @@ public class DefaultRackApplicationFactory implements RackApplicationFactory {
 
     protected IRubyObject createRackServletWrapper(Ruby runtime, String rackup) {
         return runtime.evalScriptlet(
-                "load 'jruby/rack/boot/rack.rb'\n"
+                "load 'jruby/rack/boot/rack.rb';"
                 +"Rack::Handler::Servlet.new(Rack::Builder.new {( "
                 + rackup + "\n )}.to_app)");
     }


### PR DESCRIPTION
I was running into errors in config.ru (specifically with the standard Rails config.ru files which use **FILE**) and having trouble understanding them because the line numbers didn't seem to match up.

This patch should correct that problem. Additionally it'd be helpful if you could somehow pass the path to config.ru to runtime/evalScriptlet in some manner, not only to make errors more comprehensible, but to make sure **FILE** is set appropriately and standard Rails 3 config.ru files work.
