### PR TITLE
Remove Trailing Slash from jruby.home

### DIFF
--- a/src/main/java/org/jruby/rack/DefaultRackApplicationFactory.java
+++ b/src/main/java/org/jruby/rack/DefaultRackApplicationFactory.java
@@ -112,11 +112,18 @@ public class DefaultRackApplicationFactory implements RackApplicationFactory {
         try { // try to set jruby home to jar file path
             URL resource = RubyInstanceConfig.class.getResource("/META-INF/jruby.home");
             if (resource.getProtocol().equals("jar")) {
+                String home;
                 try { // http://weblogs.java.net/blog/2007/04/25/how-convert-javaneturl-javaiofile
-                    config.setJRubyHome(resource.toURI().getSchemeSpecificPart());
+                    home = resource.toURI().getSchemeSpecificPart();
                 } catch (URISyntaxException urise) {
-                    config.setJRubyHome(resource.getPath());
+                    home = resource.getPath();
+                } 
+                
+                // Cut of trailing slash. It confuses OSGi containers...
+                if (home.endsWith("/")) {
+                    home = home.substring(0, home.length() - 1);
                 }
+                config.setJRubyHome(home);
             }
         } catch (Exception e) { }
         return config;


### PR DESCRIPTION
Hi Nick,

   I ran into problems using jruby-rack inside of an Equinox based OSGi container. It turns out that there was an extra slash in the JRuby home path. This made it impossible for JRuby to resolve anything.

This commit removes trailing slashes from the URI before it gets passed into RubyInstanceConfig. 

I'm not sure if the problem should really be fixed in jruby-rack though. Maybe it should be in RubyInstanceConfig or even further down in org.jruby.util.NormalizedFile.

Cheers,

  Michael
