### PR TITLE
Properly convert a java.net.URL to a valid filename.

### DIFF
--- a/src/main/ruby/jruby/rack/booter.rb
+++ b/src/main/ruby/jruby/rack/booter.rb
@@ -87,7 +87,15 @@ module JRuby::Rack
                ensure
                  stream.close rescue nil
                end
-        eval code, TOPLEVEL_BINDING, url.path
+        eval code, TOPLEVEL_BINDING, path_to_file(url)
+      end
+    end
+
+    def path_to_file(url)
+      begin
+        return java.io.File.new(url.toURI()).to_s
+      rescue java.net.URISyntaxException => e
+        return java.io.File.new(url.getPath()).to_s
       end
     end
   end


### PR DESCRIPTION
Using File.expand_path('some/path', **FILE**) breaks in [WEB|META]-inf/init.rb because of incorrect path handling of java's URL.

See http://weblogs.java.net/blog/kohsuke/archive/2007/04/how_to_convert.html for an explanation of this fix.
