### PR TITLE
fix/workaround for #25

### DIFF
--- a/src/main/ruby/jruby/rack/session_store.rb
+++ b/src/main/ruby/jruby/rack/session_store.rb
@@ -108,6 +108,8 @@ module JRuby::Rack
 
     def close_session(env)
       (session = get_servlet_session(env)) and session.invalidate
+    rescue => exception
+      nil
     end
 
     def current_session_id(env)


### PR DESCRIPTION
Swallow/squash exception from session.invalidate in cases where it's already invalidated.  This keeps from blowing up the ServletFilter on redirects in glassfishv3.
