### PR TITLE
jruby.runtime.arguments

### DIFF
--- a/src/main/java/org/jruby/rack/DefaultRackApplicationFactory.java
+++ b/src/main/java/org/jruby/rack/DefaultRackApplicationFactory.java
@@ -141,9 +141,11 @@ public class DefaultRackApplicationFactory implements RackApplicationFactory {
 
     private RubyInstanceConfig createDefaultConfig() {
         setupJRubyManagement();
-        RubyInstanceConfig config = new RubyInstanceConfig();
+        final RubyInstanceConfig config = new RubyInstanceConfig();
         config.setLoader(Thread.currentThread().getContextClassLoader());
-
+        // Process arguments, namely any that might be in RUBYOPT
+        config.processArguments(rackContext.getConfig().getRuntimeArguments());
+        
         if (rackContext.getConfig().getCompatVersion() != null) {
             config.setCompatVersion(rackContext.getConfig().getCompatVersion());
         }
@@ -166,8 +168,6 @@ public class DefaultRackApplicationFactory implements RackApplicationFactory {
             }
         } catch (Exception e) { }
 
-        // Process arguments, namely any that might be in RUBYOPT
-        config.processArguments(new String[0]);
         return config;
     }
 

--- a/src/main/java/org/jruby/rack/DefaultRackConfig.java
+++ b/src/main/java/org/jruby/rack/DefaultRackConfig.java
@@ -58,6 +58,11 @@ public class DefaultRackConfig implements RackConfig {
         return getPositiveInteger("jruby.runtime.timeout.sec");
     }
 
+    public String[] getRuntimeArguments() {
+        final String args = getProperty("jruby.runtime.arguments");
+        return args == null ? null : args.trim().split("\\s+");
+    }
+    
     public Integer getNumInitializerThreads() {
         return getPositiveInteger("jruby.runtime.initializer.threads");
     }

--- a/src/main/java/org/jruby/rack/RackConfig.java
+++ b/src/main/java/org/jruby/rack/RackConfig.java
@@ -31,6 +31,9 @@ public interface RackConfig {
     /** Get the number of maximum runtimes, or null if unspecified. */
     Integer getMaximumRuntimes();
 
+    /** Return (optional) command line arguments to be used to configure runtimes. */
+    String[] getRuntimeArguments();
+    
     /** Get the number of initializer threads, or null if unspecified. */
     Integer getNumInitializerThreads();
 

--- a/src/spec/ruby/rack/application_spec.rb
+++ b/src/spec/ruby/rack/application_spec.rb
@@ -117,6 +117,13 @@ describe DefaultRackApplicationFactory do
         lambda { runtime.evalScriptlet('ENV["HOME"]') == nil }.should be_true
       end
 
+      it "should handle jruby.runtime.arguments == '-X+O -Ke' and start with object space enabled and KCode EUC" do
+        @rack_config.stub!(:getRuntimeArguments).and_return ['-X+O', '-Ke'].to_java(:String)
+        runtime = app_factory.new_runtime
+        runtime.object_space_enabled.should be_true
+        runtime.kcode.should == Java::OrgJrubyUtil::KCode::EUC
+      end
+      
       def eval_should_be_true(value, expected)
         (value == expected).should be_true
       end

--- a/src/spec/ruby/rack/config_spec.rb
+++ b/src/spec/ruby/rack/config_spec.rb
@@ -61,6 +61,32 @@ describe ServletRackConfig do
     end
   end
 
+  describe "runtime arguments" do
+    it "should retrieve single argument from jruby.runtime.arguments" do
+      @servlet_context.should_receive(:getInitParameter).with("jruby.runtime.arguments").and_return nil
+      config.runtime_arguments.should be_nil
+    end
+    
+    it "should retrieve single argument from jruby.runtime.arguments" do
+      @servlet_context.should_receive(:getInitParameter).with("jruby.runtime.arguments").and_return "--profile"
+      args = config.runtime_arguments
+      args.should_not be_nil
+      args.length.should == 1
+      args[0].should == "--profile"
+    end
+    
+    it "should retrieve multiple argument from jruby.runtime.arguments" do
+      @servlet_context.should_receive(:getInitParameter).with("jruby.runtime.arguments").and_return " --compat RUBY1_8 \n --profile.api  --debug  \n\r"
+      args = config.runtime_arguments
+      args.should_not be_nil
+      args.length.should == 4
+      args[0].should == "--compat"
+      args[1].should == "RUBY1_8"
+      args[2].should == "--profile.api"
+      args[3].should == "--debug"
+    end
+  end
+  
   describe "rewindable" do
     it "defaults to true" do
       config.should be_rewindable


### PR DESCRIPTION
 Hey once again,

I was trying to accomplish a goal of being able to `--profile` a runtime created by **jruby-rack** thus I added (generic) support for passing "command-line" arguments via a `jruby.runtime.arguments` parameter. e.g. :

```
<context-param>
    <param-name>jruby.runtime.arguments</param-name>
    <param-value>--profile</param-value>
</context-param>
```

Of course one can pass anything `jruby` accepts on the command-line, but my main motivation would be profiling within a container, it ain't perfect as it interferes with trapping signals (if the container such as **trinidad** does `trap` ^C).

Unfortunately it does not work as expected and I was hoping for some advice, if it's doable or I'm heading towards a dead-end. 
I'm running `jruby -J-Djruby.runtime.arguments=--profile -S trinidad` the runtime ends up being profiled as expected but all method names are shown as `<unknown>` :

```
main thread profile results:
Total time: 10.43

     total        self    children       calls  method
----------------------------------------------------------------
     10.39        0.01       10.38        3293  <unknown>
     10.23        0.00       10.23        3594  <unknown>
     10.23        0.00       10.23           1  <unknown>
     10.23        0.00       10.23          14  <unknown>
     10.23        0.00       10.23           1  <unknown>
     10.23        0.00       10.23           1  <unknown>
     10.23        0.00       10.23           1  <unknown>
      ...
```

Is there anything I could do to make the method names "visible" ?

Appreciate any input ...
