### PR TITLE
move JavaServletStore setup for Rails 3.x to a railtie initializer

### DIFF
--- a/src/main/ruby/jruby/rack/rails.rb
+++ b/src/main/ruby/jruby/rack/rails.rb
@@ -89,7 +89,7 @@ module JRuby::Rack
             asset_tag_helper.const_set("STYLESHEETS_DIR", "#{PUBLIC_ROOT}/stylesheets")
           end
         end
-        require 'jruby/rack/rails/extensions'
+        require 'jruby/rack/rails/extensions2'
       end
 
       def rack_based_sessions?
@@ -130,7 +130,7 @@ module JRuby::Rack
       end
 
       def session_options
-        @session_options ||= SESSION_OPTIONS
+        @session_options ||= ActionController::CgiRequest::DEFAULT_SESSION_OPTIONS
       end
 
       def set_session_options_for_request(env)
@@ -164,9 +164,8 @@ module JRuby::Rack
       def load_environment
         require File.join(app_path, 'config', 'boot')
         require 'jruby/rack/rails/railtie'
-        require 'jruby/rack/rails/extensions'
-        require 'jruby/rack/rails/extensions3'
         require File.join(app_path, 'config', 'environment')
+        require 'jruby/rack/rails/extensions3'
       end
 
       def to_app

--- a/src/main/ruby/jruby/rack/rails/extensions.rb
+++ b/src/main/ruby/jruby/rack/rails/extensions.rb
@@ -8,23 +8,6 @@
 require 'action_controller'
 
 module ActionController
-  class CgiRequest #:nodoc:
-    # Replace session_options writer to merge session options
-    # With ones passed into request (so we can preserve the
-    # java servlet request)
-    def session_options=(opts)
-      if opts == false
-        @session_options = false
-      elsif @session_options
-        @session_options.update(opts)
-      else
-        @session_options = opts
-      end
-    end
-
-    DEFAULT_SESSION_OPTIONS = {} unless defined?(DEFAULT_SESSION_OPTIONS)
-  end
-
   class Base
     def servlet_request
       request.env['java.servlet_request']
@@ -34,41 +17,4 @@ module ActionController
       request.forward_to(url)
     end
   end
-
-  module Session
-    autoload :JavaServletStore, "action_controller/session/java_servlet_store"
-  end
-
-  # These rescue module overrides should only be needed for pre-Rails 2.1
-  unless defined?(::Rails.public_path)
-    module Rescue
-      # Rails 2.0 static rescue files
-      def render_optional_error_file(status_code) #:nodoc:
-        status = interpret_status(status_code)
-        path = "#{PUBLIC_ROOT}/#{status[0,3]}.html"
-        if File.exists?(path)
-          render :file => path, :status => status
-        else
-          head status
-        end
-      end
-
-      def rescue_action_in_public(exception) #:nodoc:
-        if respond_to?(:render_optional_error_file) # Rails 2
-          render_optional_error_file response_code_for_rescue(exception)
-        else # Rails 1
-          case exception
-          when RoutingError, UnknownAction
-            render_text(IO.read(File.join(PUBLIC_ROOT, '404.html')), "404 Not Found")
-          else
-            render_text(IO.read(File.join(PUBLIC_ROOT, '500.html')), "500 Internal Error")
-          end
-        end
-      end
-    end
-  end
-end
-
-module JRuby::Rack
-  SESSION_OPTIONS = ActionController::CgiRequest::DEFAULT_SESSION_OPTIONS
 end

--- a/src/main/ruby/jruby/rack/rails/extensions2.rb
+++ b/src/main/ruby/jruby/rack/rails/extensions2.rb
@@ -1,0 +1,62 @@
+#--
+# Copyright (c) 2010-2011 Engine Yard, Inc.
+# Copyright (c) 2007-2009 Sun Microsystems, Inc.
+# This source code is available under the MIT license.
+# See the file LICENSE.txt for details.
+#++
+
+require 'jruby/rack/rails/extensions'
+
+require 'action_controller'
+
+module ActionController
+  class CgiRequest #:nodoc:
+    # Replace session_options writer to merge session options
+    # With ones passed into request (so we can preserve the
+    # java servlet request)
+    def session_options=(opts)
+      if opts == false
+        @session_options = false
+      elsif @session_options
+        @session_options.update(opts)
+      else
+        @session_options = opts
+      end
+    end
+
+    DEFAULT_SESSION_OPTIONS = {} unless defined?(DEFAULT_SESSION_OPTIONS)
+  end
+
+  module Session
+    autoload :JavaServletStore, "action_controller/session/java_servlet_store"
+  end
+
+  # These rescue module overrides should only be needed for pre-Rails 2.1
+  unless defined?(::Rails.public_path)
+    module Rescue
+      # Rails 2.0 static rescue files
+      def render_optional_error_file(status_code) #:nodoc:
+        status = interpret_status(status_code)
+        path = "#{PUBLIC_ROOT}/#{status[0,3]}.html"
+        if File.exists?(path)
+          render :file => path, :status => status
+        else
+          head status
+        end
+      end
+
+      def rescue_action_in_public(exception) #:nodoc:
+        if respond_to?(:render_optional_error_file) # Rails 2
+          render_optional_error_file response_code_for_rescue(exception)
+        else # Rails 1
+          case exception
+          when RoutingError, UnknownAction
+            render_text(IO.read(File.join(PUBLIC_ROOT, '404.html')), "404 Not Found")
+          else
+            render_text(IO.read(File.join(PUBLIC_ROOT, '500.html')), "500 Internal Error")
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/main/ruby/jruby/rack/rails/extensions3.rb
+++ b/src/main/ruby/jruby/rack/rails/extensions3.rb
@@ -5,9 +5,4 @@
 # See the file LICENSE.txt for details.
 #++
 
-require 'action_dispatch'
-module ActionDispatch
-  module Session
-    autoload :JavaServletStore, "action_dispatch/session/java_servlet_store"
-  end
-end
+require 'jruby/rack/rails/extensions'

--- a/src/main/ruby/jruby/rack/rails/railtie.rb
+++ b/src/main/ruby/jruby/rack/rails/railtie.rb
@@ -48,5 +48,16 @@ module JRuby::Rack
         ActionController::Base.config.relative_url_root = ENV['RAILS_RELATIVE_URL_ROOT']
       end
     end
+    
+    initializer "action_dispatch.autoload_java_servlet_store", :after => "action_dispatch.configure" do
+      # if it's loaded up front with a require 'action_controller'/'action_dispatch' then
+      # it might fire up before 'active_record' has been required causing sweeping issues
+      # @see https://github.com/jruby/jruby-rack/issues/42
+      # loading it after the environment boots is too late as it might be set in a user
+      # config/initializer: MyApp::Application.config.session_store :java_servlet_store
+      ActionDispatch::Session.module_eval do
+        autoload :JavaServletStore, "action_dispatch/session/java_servlet_store"
+      end
+    end
   end
 end

--- a/src/spec/ruby/jruby/rack/rails_spec.rb
+++ b/src/spec/ruby/jruby/rack/rails_spec.rb
@@ -231,7 +231,6 @@ describe JRuby::Rack, "Rails controller extensions" do
 
   it "should add a #forward_to method for forwarding to another servlet" do
     @servlet_response = mock "servlet response"
-    dispatcher = mock "dispatcher"
     @controller.request.should_receive(:forward_to).with("/forward.jsp")
 
     @controller.forward_to "/forward.jsp"


### PR DESCRIPTION
verified that this handles issue #42 correctly (tested on Rails 3.0.10).
I could not thing of another way to resolve the `autoload :JavaServletStore` correctly.
sadly no tests - I guess we'll need some spec rearrangements to be able to test things like this one.
