### PR TITLE
Stop using BufferedLogger

### DIFF
--- a/src/main/ruby/jruby/rack/rails/railtie.rb
+++ b/src/main/ruby/jruby/rack/rails/railtie.rb
@@ -33,13 +33,8 @@ module JRuby::Rack
       end
     end
 
-    initializer "set_servlet_logger", :after => :initialize_logger do |app|
-      class << Rails.logger # Make these accessible to wire in the log device
-        public :instance_variable_get, :instance_variable_set
-      end
-      old_device = Rails.logger.instance_variable_get "@log"
-      old_device.close rescue nil
-      Rails.logger.instance_variable_set "@log", JRuby::Rack.booter.logdev
+    initializer "set_servlet_logger", :before => :initialize_logger do |app|
+      app.config.logger = JRuby::Rack.booter.logger
     end
 
     initializer "set_relative_url_root", :after => "action_controller.set_configs" do |app|


### PR DESCRIPTION
This commit will set the config.logger to the ruby standard library logger
instead of the ActiveSupport::BufferedLogger. The ActiveSupport::BufferedLogger
is being deprecated:

https://github.com/rails/rails/commit/572c3d517899524c2a7c4c84ad9646660168d4cd

Also, it was kind of hacky having to dig into the BufferedLogger's internal state in order to reset it's log device.
