### PR TITLE
fix warning in Rack::Utils::Response#write_headers

### DIFF
--- a/src/main/ruby/jruby/rack/response.rb
+++ b/src/main/ruby/jruby/rack/response.rb
@@ -105,7 +105,7 @@ module JRuby
       # Writes the response headers.
       # @see #respond
       def write_headers(response)
-        for key, value in @headers
+        @headers.each do |key, value|
           case key
           when /^Content-Type$/i
             response.setContentType(value.to_s)


### PR DESCRIPTION
jruby complains about

```
rack/utils.rb:440 warning: multiple values for a block parameter (2 for 1)
```

This had a warning

```
require 'rack/utils'

h = Rack::Utils::HeaderHash.new
h[:key] = :value

for k, v in h
  puts [k, v].inspect
end
```

But this not

```
h.each do |k, v|
  puts [k, v].inspect
end
```

So we should use each-like iterator instead of for-loop (follow the [ruby style guide](https://github.com/bbatsov/ruby-style-guide#syntax)).
