### PR TITLE
Suppress warnings unresolved warnings

### DIFF
--- a/src/main/java/org/jruby/rack/AbstractServlet.java
+++ b/src/main/java/org/jruby/rack/AbstractServlet.java
@@ -8,6 +8,7 @@
 package org.jruby.rack;
 
 import java.io.IOException;
+
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
@@ -22,6 +23,7 @@ import org.jruby.rack.servlet.ServletRackResponseEnvironment;
  *
  * @author nicksieger
  */
+@SuppressWarnings("serial")
 public abstract class AbstractServlet extends HttpServlet {
 
     @Override

--- a/src/main/java/org/jruby/rack/AcquireTimeoutException.java
+++ b/src/main/java/org/jruby/rack/AcquireTimeoutException.java
@@ -9,6 +9,7 @@ package org.jruby.rack;
  * 
  * @author kares
  */
+@SuppressWarnings("serial")
 public class AcquireTimeoutException extends RackException {
     
     public AcquireTimeoutException(String message) {

--- a/src/main/java/org/jruby/rack/DefaultErrorApplication.java
+++ b/src/main/java/org/jruby/rack/DefaultErrorApplication.java
@@ -82,6 +82,7 @@ public class DefaultErrorApplication extends DefaultRackApplication
     private class Response implements RackResponse {
 
         private int status = 500;
+        @SuppressWarnings("rawtypes")
         private Map headers = Collections.EMPTY_MAP;
         private String body;
         
@@ -93,15 +94,18 @@ public class DefaultErrorApplication extends DefaultRackApplication
             return status;
         }
 
+        @SuppressWarnings("unused")
         public void setStatus(int status) {
             this.status = status;
         }
         
+        @SuppressWarnings("rawtypes")
         public Map getHeaders() {
             return headers;
         }
 
-        public void setHeaders(Map headers) {
+        @SuppressWarnings("unused")
+        public void setHeaders(@SuppressWarnings("rawtypes") Map headers) {
             this.headers = headers == null ? Collections.EMPTY_MAP : headers;
         }
         
@@ -118,6 +122,7 @@ public class DefaultErrorApplication extends DefaultRackApplication
             return body;
         }
 
+        @SuppressWarnings("unused")
         public void setBody(String body) {
             this.body = body;
         }

--- a/src/main/java/org/jruby/rack/PoolingRackApplicationFactory.java
+++ b/src/main/java/org/jruby/rack/PoolingRackApplicationFactory.java
@@ -283,6 +283,7 @@ public class PoolingRackApplicationFactory extends RackApplicationFactoryDecorat
      * @param apps the (initial) instances (for the pool) to be initialized
      */
     protected void launchInitialization(final Queue<RackApplication> apps) {
+        @SuppressWarnings("deprecation")
         Integer initThreads = getConfig().getNumInitializerThreads();
         if ( initThreads == null ) initThreads = 4; // quad-core baby
         

--- a/src/main/java/org/jruby/rack/RackException.java
+++ b/src/main/java/org/jruby/rack/RackException.java
@@ -13,6 +13,7 @@ import org.jruby.exceptions.RaiseException;
  * 
  * @author kares
  */
+@SuppressWarnings("serial")
 public class RackException extends RuntimeException {
 
     public RackException(String message) {

--- a/src/main/java/org/jruby/rack/RackInitializationException.java
+++ b/src/main/java/org/jruby/rack/RackInitializationException.java
@@ -9,6 +9,7 @@ package org.jruby.rack;
 
 import org.jruby.exceptions.RaiseException;
 
+@SuppressWarnings("serial")
 public class RackInitializationException extends RackException {
     
     public RackInitializationException(String msg) {

--- a/src/main/java/org/jruby/rack/RackInput.java
+++ b/src/main/java/org/jruby/rack/RackInput.java
@@ -34,6 +34,7 @@ import org.jruby.util.ByteList;
  * 
  * @author nicksieger
  */
+@SuppressWarnings("serial")
 public class RackInput extends RubyObject {
     
     private static final ObjectAllocator ALLOCATOR = new ObjectAllocator() {
@@ -44,7 +45,7 @@ public class RackInput extends RubyObject {
 
     @Deprecated
     public static RubyClass getClass(Ruby runtime, String name, RubyClass parent,
-                                     ObjectAllocator allocator, Class annoClass) {
+                                     ObjectAllocator allocator, Class<?> annoClass) {
         RubyModule jruby = runtime.getOrCreateModule("JRuby");
         
         RubyClass klass = jruby.getClass(name);

--- a/src/main/java/org/jruby/rack/RackResponse.java
+++ b/src/main/java/org/jruby/rack/RackResponse.java
@@ -26,6 +26,7 @@ public interface RackResponse {
     /**  
      * @return the response headers
      */
+    @SuppressWarnings("rawtypes")
     Map getHeaders();
     
     /** 

--- a/src/main/java/org/jruby/rack/RackServlet.java
+++ b/src/main/java/org/jruby/rack/RackServlet.java
@@ -9,6 +9,7 @@ package org.jruby.rack;
 
 import javax.servlet.ServletConfig;
 
+@SuppressWarnings("serial")
 public class RackServlet extends AbstractServlet {
 
     private RackDispatcher dispatcher;

--- a/src/main/java/org/jruby/rack/RackTag.java
+++ b/src/main/java/org/jruby/rack/RackTag.java
@@ -15,6 +15,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.tagext.TagSupport;
 
+@SuppressWarnings("serial")
 public class RackTag extends TagSupport {
     private String path;
     private String params;

--- a/src/main/java/org/jruby/rack/embed/Dispatcher.java
+++ b/src/main/java/org/jruby/rack/embed/Dispatcher.java
@@ -10,10 +10,7 @@ package org.jruby.rack.embed;
 import java.io.IOException;
 
 import org.jruby.Ruby;
-import org.jruby.RubyModule;
-import org.jruby.javasupport.JavaEmbedUtils;
 import org.jruby.javasupport.JavaUtil;
-
 import org.jruby.rack.AbstractRackDispatcher;
 import org.jruby.rack.DefaultRackApplication;
 import org.jruby.rack.RackApplication;
@@ -21,7 +18,6 @@ import org.jruby.rack.RackContext;
 import org.jruby.rack.RackEnvironment;
 import org.jruby.rack.RackInitializationException;
 import org.jruby.rack.RackResponseEnvironment;
-
 import org.jruby.runtime.builtin.IRubyObject;
 
 /**

--- a/src/main/java/org/jruby/rack/embed/Servlet.java
+++ b/src/main/java/org/jruby/rack/embed/Servlet.java
@@ -13,6 +13,7 @@ import org.jruby.rack.AbstractServlet;
 import org.jruby.rack.RackContext;
 import org.jruby.rack.RackDispatcher;
 
+@SuppressWarnings("serial")
 public class Servlet extends AbstractServlet {
 
     private final Dispatcher dispatcher;

--- a/src/main/java/org/jruby/rack/jms/DefaultQueueManager.java
+++ b/src/main/java/org/jruby/rack/jms/DefaultQueueManager.java
@@ -53,9 +53,11 @@ public class DefaultQueueManager implements QueueManager {
 
     public void init(RackContext context) throws Exception {
         this.context = (ServletRackContext) context;
+        @SuppressWarnings("deprecation")
         String jndiName = context.getConfig().getJmsConnectionFactory();
         if (jndiName != null && connectionFactory == null) {
             Properties properties = new Properties();
+            @SuppressWarnings("deprecation")
             String jndiProperties = context.getConfig().getJmsJndiProperties();
             if (jndiProperties != null) {
                 properties.load(new ByteArrayInputStream(jndiProperties.getBytes("UTF-8")));

--- a/src/main/java/org/jruby/rack/servlet/DefaultServletRackContext.java
+++ b/src/main/java/org/jruby/rack/servlet/DefaultServletRackContext.java
@@ -25,6 +25,7 @@ import java.util.Set;
  *
  * @author nicksieger
  */
+@SuppressWarnings("rawtypes")
 public class DefaultServletRackContext implements ServletRackContext {
     
     private final RackConfig config;

--- a/src/main/java/org/jruby/rack/servlet/RequestCapture.java
+++ b/src/main/java/org/jruby/rack/servlet/RequestCapture.java
@@ -26,6 +26,7 @@ import org.jruby.rack.RackConfig;
 /**
  * Request wrapper passed to filter chain.
  */
+@SuppressWarnings("rawtypes")
 public class RequestCapture extends HttpServletRequestWrapper {
 
     private Map<String,String[]> requestParams;

--- a/src/main/java/org/jruby/rack/servlet/ServletRackEnvironment.java
+++ b/src/main/java/org/jruby/rack/servlet/ServletRackEnvironment.java
@@ -27,7 +27,7 @@ import org.jruby.rack.RackInput;
  * 
  * @author nicksieger
  */
-@SuppressWarnings("deprecation")
+@SuppressWarnings("unchecked")
 public class ServletRackEnvironment extends HttpServletRequestWrapper
     implements RackEnvironment, RackEnvironment.ToIO {
     

--- a/src/main/java/org/jruby/rack/servlet/ServletRackResponseEnvironment.java
+++ b/src/main/java/org/jruby/rack/servlet/ServletRackResponseEnvironment.java
@@ -30,6 +30,7 @@ public class ServletRackResponseEnvironment extends HttpServletResponseWrapper
         super(response);
     }
     
+    @SuppressWarnings("rawtypes")
     public void defaultRespond(final RackResponse response) throws IOException {
         setStatus(response.getStatus());
         @SuppressWarnings("unchecked")

--- a/src/spec/java/org/jruby/rack/fake/FakePageContext.java
+++ b/src/spec/java/org/jruby/rack/fake/FakePageContext.java
@@ -9,6 +9,7 @@ package org.jruby.rack.fake;
 
 import java.io.IOException;
 import java.util.Enumeration;
+
 import javax.el.ELContext;
 import javax.servlet.Servlet;
 import javax.servlet.ServletConfig;
@@ -27,6 +28,7 @@ import javax.servlet.jsp.el.VariableResolver;
 /**
  * Currently only used as a mock for testing.
  */
+@SuppressWarnings("deprecation")
 public class FakePageContext extends PageContext {
     private ServletContext context;
     private ServletRequest request;

--- a/src/spec/java/org/jruby/rack/mock/HeaderValueHolder.java
+++ b/src/spec/java/org/jruby/rack/mock/HeaderValueHolder.java
@@ -96,7 +96,7 @@ class HeaderValueHolder {
 	 * @param array the array to merge (may be <code>null</code>)
 	 * @param collection the target Collection to merge the array into
 	 */
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({"unchecked","rawtypes"})
 	private static void mergeArrayIntoCollection(Object array, Collection collection) {
 		if (collection == null) {
 			throw new IllegalArgumentException("Collection must not be null");
@@ -130,7 +130,7 @@ class HeaderValueHolder {
 		if (length == 0) {
 			return new Object[0];
 		}
-		Class wrapperType = Array.get(source, 0).getClass();
+		Class<?> wrapperType = Array.get(source, 0).getClass();
 		Object[] newArray = (Object[]) Array.newInstance(wrapperType, length);
 		for (int i = 0; i < length; i++) {
 			newArray[i] = Array.get(source, i);

--- a/src/spec/java/org/jruby/rack/mock/LinkedCaseInsensitiveMap.java
+++ b/src/spec/java/org/jruby/rack/mock/LinkedCaseInsensitiveMap.java
@@ -35,6 +35,7 @@ import java.util.Map;
  *
  * @author Juergen Hoeller
  */
+@SuppressWarnings("serial")
 class LinkedCaseInsensitiveMap<V> extends LinkedHashMap<String, V> {
 
 	private final Map<String, String> caseInsensitiveKeys;


### PR DESCRIPTION
I just wanted to clean up all the scattered warnings in the code.  Mostly, just suppressed deprecation, rawtype, serialization and unused warnings.
