### PR TITLE
fix https://github.com/jruby/jruby-rack/issues/153

### DIFF
--- a/src/main/java/org/jruby/rack/servlet/ResponseCapture.java
+++ b/src/main/java/org/jruby/rack/servlet/ResponseCapture.java
@@ -28,7 +28,7 @@ public class ResponseCapture extends HttpServletResponseWrapper {
     
     private static Collection<Integer> defaultNotHandledStatuses = Collections.singleton(404);
     
-    private int status = 200;
+    private int status = 404;
     private Object output;
     
     private Collection<Integer> notHandledStatuses = defaultNotHandledStatuses;

--- a/src/spec/ruby/rack/servlet/response_capture_spec.rb
+++ b/src/spec/ruby/rack/servlet/response_capture_spec.rb
@@ -13,6 +13,7 @@ describe ResponseCapture do
     servlet_response = MockHttpServletResponse.new
 
     response_capture = ResponseCapture.new(servlet_response)
+    response_capture.isHandled.should == false
     response_capture.isOutputAccessed.should == false
     
     response_capture.getOutputStream


### PR DESCRIPTION
Fixes https://github.com/jruby/jruby-rack/issues/153

with OPTIONS methods, no filter/servlet was actually handling so the status code was left untouched (as 200).

but 200 was considered handled, so the request is not passed to Ruby at all.
