### PR TITLE
use .equals() rather than == since the level string is not always the sa...

### DIFF
--- a/src/main/java/org/jruby/rack/logging/CommonsLoggingLogger.java
+++ b/src/main/java/org/jruby/rack/logging/CommonsLoggingLogger.java
@@ -33,16 +33,16 @@ public class CommonsLoggingLogger implements RackLogger {
     }
     
     public void log(String level, String message) {
-        if (level == ERROR) {
+        if (ERROR.equals(level)) {
             logger.error(message);
         }
-        else if (level == WARN) {
+        else if (WARN.equals(level)) {
             logger.warn(message);
         }
-        else if (level == INFO) {
+        else if (INFO.equals(level)) {
             logger.info(message);
         }
-        else if (level == DEBUG) {
+        else if (DEBUG.equals(level)) {
             logger.debug(message);
         }
         else {
@@ -51,16 +51,16 @@ public class CommonsLoggingLogger implements RackLogger {
     }
 
     public void log(String level, String message, Throwable e) {
-        if (level == ERROR) {
+        if (ERROR.equals(level)) {
             logger.error(message, e);
         }
-        else if (level == WARN) {
+        else if (WARN.equals(level)) {
             logger.warn(message, e);
         }
-        else if (level == INFO) {
+        else if (INFO.equals(level)) {
             logger.info(message, e);
         }
-        else if (level == DEBUG) {
+        else if (DEBUG.equals(level)) {
             logger.debug(message, e);
         }
         else {

--- a/src/main/java/org/jruby/rack/logging/JulLogger.java
+++ b/src/main/java/org/jruby/rack/logging/JulLogger.java
@@ -48,10 +48,10 @@ public class JulLogger implements RackLogger {
     }
     
     private static Level mapLevel(String level, Level defaultLevel) {
-        if ( level == ERROR ) return Level.SEVERE;
-        if ( level == WARN )  return Level.WARNING;
-        if ( level == INFO )  return Level.INFO;
-        if ( level == DEBUG ) return Level.FINE;
+        if (ERROR.equals(level)) return Level.SEVERE;
+        if (WARN.equals(level))  return Level.WARNING;
+        if (INFO.equals(level))  return Level.INFO;
+        if (DEBUG.equals(level)) return Level.FINE;
         return defaultLevel;
     }
     

--- a/src/main/java/org/jruby/rack/logging/Log4jLogger.java
+++ b/src/main/java/org/jruby/rack/logging/Log4jLogger.java
@@ -36,16 +36,16 @@ public class Log4jLogger implements RackLogger {
     }
 
     public void log(String level, String message) {
-        if (level == ERROR) {
+        if (ERROR.equals(level)) {
             logger.error(message);
         }
-        else if (level == WARN) {
+        else if (WARN.equals(level)) {
             logger.warn(message);
         }
-        else if (level == INFO) {
+        else if (INFO.equals(level)) {
             logger.info(message);
         }
-        else if (level == DEBUG) {
+        else if (DEBUG.equals(level)) {
             logger.debug(message);
         }
         else {
@@ -54,16 +54,16 @@ public class Log4jLogger implements RackLogger {
     }
 
     public void log(String level, String message, Throwable e) {
-        if (level == ERROR) {
+        if (ERROR.equals(level)) {
             logger.error(message, e);
         }
-        else if (level == WARN) {
+        else if (WARN.equals(level)) {
             logger.warn(message, e);
         }
-        else if (level == INFO) {
+        else if (INFO.equals(level)) {
             logger.info(message, e);
         }
-        else if (level == DEBUG) {
+        else if (DEBUG.equals(level)) {
             logger.debug(message, e);
         }
         else {

--- a/src/main/java/org/jruby/rack/logging/Slf4jLogger.java
+++ b/src/main/java/org/jruby/rack/logging/Slf4jLogger.java
@@ -32,16 +32,16 @@ public class Slf4jLogger implements RackLogger {
     }
     
     public void log(String level, String message) {
-        if (level == ERROR) {
+        if (ERROR.equals(level)) {
             logger.error(message);
         }
-        else if (level == WARN) {
+        else if (WARN.equals(level)) {
             logger.warn(message);
         }
-        else if (level == INFO) {
+        else if (INFO.equals(level)) {
             logger.info(message);
         }
-        else if (level == DEBUG) {
+        else if (DEBUG.equals(level)) {
             logger.debug(message);
         }
         else {
@@ -50,16 +50,16 @@ public class Slf4jLogger implements RackLogger {
     }
 
     public void log(String level, String message, Throwable e) {
-        if (level == ERROR) {
+        if (ERROR.equals(level)) {
             logger.error(message, e);
         }
-        else if (level == WARN) {
+        else if (WARN.equals(level)) {
             logger.warn(message, e);
         }
-        else if (level == INFO) {
+        else if (INFO.equals(level)) {
             logger.info(message, e);
         }
-        else if (level == DEBUG) {
+        else if (DEBUG.equals(level)) {
             logger.debug(message, e);
         }
         else {


### PR DESCRIPTION
use .equals() rather than == since the level string is not always the same object instance as defined by the RackLogger interface
