### PR TITLE
Add factory exception logging

### DIFF
--- a/src/main/java/org/jruby/rack/DefaultRackApplicationFactory.java
+++ b/src/main/java/org/jruby/rack/DefaultRackApplicationFactory.java
@@ -97,7 +97,13 @@ public class DefaultRackApplicationFactory implements RackApplicationFactory {
     public RackApplication newApplication() {
         return createApplication(new ApplicationObjectFactory() {
             public IRubyObject create(Ruby runtime) {
-                return createApplicationObject(runtime);
+                try {
+                    return createApplicationObject(runtime);
+                }
+                catch (RaiseException ex) {
+                    ex.printStackTrace(rackContext.getConfig().getErr()); // write exception stacktrace to error log
+                    throw new RackInitializationException("failed to load environment", ex);
+                }
             }
         });
     }


### PR DESCRIPTION
## Overview

When loading the environment of a jruby-rack based app, such as a RoR app, if something fails in the loading process and if [properties settings](https://github.com/jruby/jruby-rack/blob/d59193e9284bce30a7cae5a8ebb7f4ae8436e110/src/main/java/org/jruby/rack/DefaultRackConfig.java#L275-L285) is not set, then the exception is left unreported, which can be confusing or misleading. This seems to have been [assumed](https://github.com/jruby/jruby-rack/blob/d59193e9284bce30a7cae5a8ebb7f4ae8436e110/src/main/java/org/jruby/rack/RackServletContextListener.java#L96) in the application.
## Changes
1. add the logic to catch any RaiseException, output the error stacktrace to error log, and raise a new `RackInitializationException`.
