### PR TITLE
allow PATCH verb to be processed by the ruby application

### DIFF
--- a/src/main/java/org/jruby/rack/UnmappedRackFilter.java
+++ b/src/main/java/org/jruby/rack/UnmappedRackFilter.java
@@ -46,7 +46,8 @@ public class UnmappedRackFilter extends AbstractFilter {
     private Collection<Integer> responseNotHandledStatuses = 
         // 403 due containers not supporting PUT/DELETE correctly (Tomcat 6)
         // 405 returned by Jetty 7/8 on PUT/DELETE requests by default
-        Collections.unmodifiableList( Arrays.asList(404, 403, 405) );
+        // 501 is returned for non standard http verbs like PATCH
+        Collections.unmodifiableList( Arrays.asList(404, 403, 405, 501) );
     
     private RackContext context;
     private RackDispatcher dispatcher;

--- a/src/spec/ruby/rack/filter_spec.rb
+++ b/src/spec/ruby/rack/filter_spec.rb
@@ -86,6 +86,17 @@ describe org.jruby.rack.RackFilter do
     filter.doFilter(@request, @response, chain)
   end
   
+  it "dispatches to the rack dispatcher if the chain resulted in a 501" do
+    # non standard verbs like PATCH produce HTTP 501
+    # see also http://httpstatus.es/501 and http://tools.ietf.org/html/rfc5789
+    chain.should_receive(:doFilter).ordered.and_return do |_, resp|
+      resp.sendError(501)
+    end
+    @response.should_receive(:reset)
+    dispatcher.should_receive(:process)
+    filter.doFilter(@request, @response, chain)
+  end
+
   it "dispatches to the rack dispatcher out of configured non handled statuses" do
     filter = Class.new(org.jruby.rack.RackFilter) do
       def wrapResponse(response)


### PR DESCRIPTION
the HTTP PATCH verb works with RackServlet but with RackFilter the filter chain returns 501 on those verbs and 501 is considered as handled and will not be processed by the ruby application. this patch adds 501 to the list of responses for which the request will be passed on to the ruby application.

the patch is particular important for rich client using rest(ful) API servers. the PATCH allows to partially updated resources on the server whereas PUT is meant to sent the full object over the wire.

Sponsored by: Lookout, Inc.
