### PR TITLE
update rack to 1.6.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ GEM
       bundler
       rake
     diff-lcs (1.2.5)
-    rack (1.5.2)
+    rack (1.6.0)
     rake (10.3.2)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)


### PR DESCRIPTION
There have been [a lot of changes to rack](https://github.com/rack/rack/compare/1.5.2...1.6.0) between 1.5.2 and 1.6.0 but all of the specs pass at least.  

The main fix I'm interested in is the XSS vulnerability in the default error app that uses Rack::ShowStatus.  The fixed issue is [here](https://github.com/rack/rack/pull/579)
