### PR TITLE
allow uri-like pathes for app.root and gem.path

### DIFF
--- a/src/main/java/org/jruby/rack/DefaultRackApplicationFactory.java
+++ b/src/main/java/org/jruby/rack/DefaultRackApplicationFactory.java
@@ -7,8 +7,10 @@
 
 package org.jruby.rack;
 
-import java.io.IOException;
+
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URISyntaxException;
@@ -524,15 +526,21 @@ public class DefaultRackApplicationFactory implements RackApplicationFactory {
                 }
             }
 
-            if (rackup != null) {
-                rackupLocation = rackContext.getRealPath(rackup);
-                try {
-                    rackup = IOHelpers.inputStreamToString(rackContext.getResourceAsStream(rackup));
+            InputStream is = null;
+            try {
+                if (rackup != null) {
+                    is = rackContext.getResourceAsStream(rackup);
+                    rackupLocation = rackContext.getRealPath(rackup);
                 }
-                catch (IOException e) {
-                    rackContext.log(RackLogger.ERROR, "failed to read rackup from '"+ rackup + "' (" + e + ")");
-                    throw new RackInitializationException("failed to read rackup input", e);
+                else {
+                    is = Thread.currentThread().getContextClassLoader().getResourceAsStream("config.ru");
+                    rackupLocation = "uri:classloader://config.ru";
                 }
+                rackup = IOHelpers.inputStreamToString(is);
+            }
+            catch (IOException e) {
+                rackContext.log(RackLogger.ERROR, "failed to read rackup from '"+ rackup + "' (" + e + ")");
+                throw new RackInitializationException("failed to read rackup input", e);
             }
         }
 

--- a/src/main/ruby/jruby/rack/app_layout.rb
+++ b/src/main/ruby/jruby/rack/app_layout.rb
@@ -40,6 +40,7 @@ module JRuby
       def real_path(path)
         real_path = @rack_context.getRealPath(path)
         real_path.chomp!('/') if real_path
+        # just use the given path if there is no real path
         real_path
       end
 
@@ -90,6 +91,31 @@ module JRuby
     end
 
     RailsWebInfLayout = WebInfLayout
+
+    class ClassPathLayout < WebInfLayout
+
+      URI_CLASSLOADER = 'uri:classloader://'
+
+      def real_path(path)
+        if path.start_with? URI_CLASSLOADER
+          path
+        else
+          super
+        end
+      end
+
+      def app_uri
+        @app_uri ||=
+          @rack_context.getInitParameter('app.root') ||
+          URI_CLASSLOADER
+      end
+
+      def gem_uri
+        @gem_uri ||=
+          @rack_context.getInitParameter('gem.path') ||
+          URI_CLASSLOADER
+      end
+    end
 
     # @deprecated will be removed (with Merb support)
     class MerbWebInfLayout < WebInfLayout


### PR DESCRIPTION
when the app.root points to uri:classlaoder:// the rack-application can be packed one-to-one into WEB-INF/classes.
similar for setting gem.path to uri:classloader:// allows to embed the gems in WEB-INF/classes.

setting the gem.path is only needed for jruby-1.7.x and app.root only works with the 1.7.19+. all this allows a simplified packaging: https://github.com/mkristian/jruby-pack#packing-jarwar-files-of-ruby-application
and bypasses all the need of real-path.