### PR TITLE
JRuby::Rack::ErrorApp response body is ignored

### DIFF
--- a/src/main/ruby/jruby/rack/error_app.rb
+++ b/src/main/ruby/jruby/rack/error_app.rb
@@ -64,6 +64,7 @@ module JRuby
       end
 
       def serve(code, path, env)
+        env['rack.showstatus.detail'] = nil
         last_modified = File.mtime(path).httpdate
         return [ 304, {}, [] ] if env['HTTP_IF_MODIFIED_SINCE'] == last_modified
 

--- a/src/spec/ruby/jruby/rack/error_app_spec.rb
+++ b/src/spec/ruby/jruby/rack/error_app_spec.rb
@@ -59,6 +59,7 @@ describe 'JRuby::Rack::ErrorApp' do
       expect( body = response[2] ).to be_a JRuby::Rack::ErrorApp::FileBody
       content = ''; body.each { |chunk| content << chunk }
       expect( content ).to eql '-503-'
+      expect( @env["rack.showstatus.detail"] ).to be_nil
     end
   end
 
@@ -77,6 +78,7 @@ describe 'JRuby::Rack::ErrorApp' do
       expect( body = response[2] ).to be_a JRuby::Rack::ErrorApp::FileBody
       content = ''; body.each { |chunk| content << chunk }
       expect( content ).to eql _500_html
+      expect( @env["rack.showstatus.detail"] ).to be_nil
     end
   end
 


### PR DESCRIPTION
When env["rack.showstatus.detail"] is true, JRuby::Rack::ErrorApp response body is overwritten by JRuby::Rack::ErrorApp::ShowStatus.
https://github.com/jruby/jruby-rack/blob/1.1.18/src/main/ruby/jruby/rack/error_app/show_status.rb#L23-L31
Currently, env["rack.showstatus.detail"] will always be true.
https://github.com/jruby/jruby-rack/blob/1.1.18/src/main/ruby/jruby/rack/error_app.rb#L59