### PR TITLE
removed use of deprecated method in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -58,7 +58,7 @@ task :unpack_gem => "target" do |t|
   if spec.respond_to?(:cache_file)
     gem_file = spec.cache_file
   else
-    gem_file = File.join(spec.installation_path, 'cache', spec.file_name)
+    gem_file = File.join(spec.base_dir, 'cache', spec.file_name)
   end
   unless uptodate?("#{target}/vendor/rack.rb", [__FILE__, gem_file])
     mkdir_p "target/vendor"

--- a/pom.xml
+++ b/pom.xml
@@ -19,11 +19,11 @@
   </description>
 
   <properties>
-    <jruby.version>1.7.19</jruby.version>
+    <jruby.version>9.0.3.0</jruby.version>
     <vendor.gems.path>vendor/gems</vendor.gems.path>
-    <bundler.version>1.7.14</bundler.version>
+    <bundler.version>1.10.6</bundler.version>
     <bundler.local>false</bundler.local> <!-- true by default -->
-    <saumya.mojo.version>1.0.9</saumya.mojo.version>
+    <saumya.mojo.version>1.1.2</saumya.mojo.version>
     <gem.home>${project.build.directory}/rubygems</gem.home>
   </properties>
 


### PR DESCRIPTION
NOTE: Gem::Specification#installation_path is deprecated, use base_dir. It will be removed on or after 2011-10-01