### PR TITLE
When handling OPTION calls ignore both 'Date' and 'Allow' headers to …

### DIFF
--- a/src/spec/ruby/rack/servlet/response_capture_spec.rb
+++ b/src/spec/ruby/rack/servlet/response_capture_spec.rb
@@ -65,6 +65,16 @@ describe org.jruby.rack.servlet.ResponseCapture do
     expect( response_capture.isHandled(servlet_request) ).to be false
   end
 
+  it "is not considered handled when only Allow or Date header is added with OPTIONS" do
+    servlet_request.method = 'OPTIONS'
+
+    # NOTE: Jetty sets both Date and Allow in DefaultServlet#doOptions
+    response_capture.addHeader "Allow", "GET, POST, OPTIONS"
+    response_capture.addHeader "Date", Time.now.httpdate
+
+    expect( response_capture.isHandled(servlet_request) ).to be false
+  end
+
   it "is considered handled when more than Allow header is added with OPTIONS" do
     pending "need Servlet API 3.0" unless servlet_30?
 


### PR DESCRIPTION
…decide if call has been handeled

If not, no OPTION calls will be passed down to the rack app due to the fact
that some implementations of DefaultServlet (i.e. Jetty and Tomcat) already sets
these fields. Fixes #205
