### PR TITLE
Don't let getSession cause an infinite loop if it throws IllegalStateException

### DIFF
--- a/src/main/ruby/jruby/rack/session_store.rb
+++ b/src/main/ruby/jruby/rack/session_store.rb
@@ -91,7 +91,12 @@ module JRuby::Rack
             unless servlet_request = env['java.servlet_request']
               raise "JavaServletStore expects a servlet request at env['java.servlet_request']"
             end
-            servlet_session = servlet_request.getSession(create)
+            servlet_session =
+              begin
+                servlet_request.getSession(create)
+              rescue java.lang.IllegalStateException => e
+                raise "Failed to obtain session due to IllegalStateException: #{e.message}"
+              end
             env[ENV_SERVLET_SESSION_KEY] = servlet_session
           end
         rescue java.lang.IllegalStateException # cached session invalidated


### PR DESCRIPTION
This fixes #215 

I have implemented this as a monkeypatch to our system and verified the infinite loop goes away for us, and figured it would be useful to submit this upstream.

I break the infinite loop by catching the `IllegalStateException` when caused by `getSession(boolean)` and throw it as a `RuntimeError` to avoid triggering the loop.

This might be better solved by restructuring the code, or changing what the begin/rescue is wrapping, or preventing infinite retries, but I patched this in our system like this to avoid making too much changes to the original code and possibly introducing a different bug.

Please let me know if you would like me to attempt a different approach.