### PR TITLE
Use encoding and CR-aware concatenation

### DIFF
--- a/src/main/java/org/jruby/rack/ext/Input.java
+++ b/src/main/java/org/jruby/rack/ext/Input.java
@@ -29,6 +29,7 @@ import org.jruby.util.ByteList;
 import org.jruby.rack.RackEnvironment;
 import org.jruby.rack.servlet.RewindableInputStream;
 import org.jruby.rack.util.ExceptionUtils;
+import org.jruby.util.StringSupport;
 
 /**
  * Native (Java) implementation of a Rack input.
@@ -143,7 +144,7 @@ public class Input extends RubyObject {
             if ( bytes != null ) {
                 if ( buffer != null ) {
                     buffer.clear();
-                    buffer.cat(bytes);
+                    buffer.catWithCodeRange(new ByteList(bytes, false), StringSupport.CR_UNKNOWN);
                     return buffer;
                 }
                 return context.runtime.newString(new ByteList(bytes, false));


### PR DESCRIPTION
The old `cat` method used here does not consider encodings or code ranges, instead just slamming the given bytes directly into the existing buffer. This causes problem when those bytes or the encoding they came from does not match the existing encoding or code range, leading to issues like jruby/jruby-rack#247.

The fix here uses a code range-aware method for doing the bytes concatenation, and resolved the related bug.

Fixes jruby/jruby-rack#247