### PR TITLE
Coderange cat for 9.3

### DIFF
--- a/src/main/java/org/jruby/rack/RackInput.java
+++ b/src/main/java/org/jruby/rack/RackInput.java
@@ -27,6 +27,7 @@ import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
+import org.jruby.util.StringSupport;
 
 /**
  * Native (Java) implementation of a Rack input.
@@ -147,7 +148,7 @@ public class RackInput extends RubyObject {
             if (bytes != null) {
                 if (string != null) {
                     string.clear();
-                    string.cat(bytes);
+                    string.cat19(new ByteList(bytes, false), StringSupport.CR_UNKNOWN);
                     return string;
                 }
                 return getRuntime().newString(new ByteList(bytes));


### PR DESCRIPTION
This is equivalent to the fix in #248 but using MethodHandle to call an appropriate version for the host JRuby.

It is also targeted at 1.1.x to have a compatible release of that version of jruby-rack without introducing larger changes.

See https://github.com/jruby/jruby-rack/issues/247#issuecomment-2151517962