### PR TITLE
Correct javax.activation scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,7 @@
       <groupId>javax.activation</groupId>
       <artifactId>activation</artifactId>
       <version>1.1</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
This only seems to be used within tests at https://github.com/jruby/jruby-rack/blob/a965a33a23a484371e81a01048714106acda6230/src/spec/java/org/jruby/rack/mock/MockServletContext.java#L466-L468 so note needed as a new runtime dependency (especially as it's a very old API version)?