### PR TITLE
Cleanup Actions workflow and dependabot ignore rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,15 @@ updates:
         dependency-type: "production"
       maven-dev-deps:
         dependency-type: "development"
+    ignore:
+      - dependency-name: "org.jruby*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+      - dependency-name: "jakarta*"
+        update-types: [ "version-update:semver-major" ]
+      - dependency-name: "javax*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+      - dependency-name: "org.springframework*"
+        update-types: [ "version-update:semver-major" ]
   - package-ecosystem: bundler
     directories:
       - "/"
@@ -26,3 +35,6 @@ updates:
     groups:
       ruby-deps:
         patterns: [ "*" ]
+    ignore:
+      - dependency-name: "rack"
+        update-types: [ "version-update:semver-major" ]

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,9 +2,9 @@ name: Java CI
 
 on:
   push:
-    branches-ignore: [ "internal*" ]
+    branches: [ "master", "*release*", "*stable*" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "master", "*release*", "*stable*" ]
 
 jobs:
   build:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ "master", "*release*", "*stable*" ]
 
+env:
+  # Default versions for canonical release build
+  DEFAULT_JAVA_VERSION: '8'
+  DEFAULT_JRUBY_VERSION: '9.4.12.1' # Should match pom.xml <jruby.version> property (AND a version inside the test matrix)
+
 jobs:
   build:
     name: JRuby ${{ matrix.jruby_version }} / Java ${{ matrix.java_version }}
@@ -39,8 +44,8 @@ jobs:
 
     # Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     - name: Update dependency graph
-      uses: advanced-security/maven-dependency-submission-action@aeab9f885293af501bae8bdfe88c589528ea5e25 # v4.1.2
-      if: github.head_ref == 'refs/heads/master' && matrix.java_version == '8' && startsWith(matrix.jruby_version, '9.4')
+      uses: advanced-security/maven-dependency-submission-action@b275d12641ac2d2108b2cbb7598b154ad2f2cee8 # v5.0.0
+      if: github.head_ref == 'refs/heads/master' && matrix.java_version == env.DEFAULT_JAVA_VERSION && matrix.jruby_version == env.DEFAULT_JRUBY_VERSION
 
   appraisals:
     needs: build
@@ -54,40 +59,10 @@ jobs:
         appraisal: [ 'rails50', 'rails52', 'rails60', 'rails61', 'rails70', 'rails71', 'rails72' ]
         exclude:
           - jruby_version: '9.3.15.0'
-            java_version: '8'
             appraisal: 'rails70' # Requires Ruby 2.7 compatibility, which JRuby 9.3 does not support
           - jruby_version: '9.3.15.0'
-            java_version: '8'
             appraisal: 'rails71' # Requires Ruby 2.7 compatibility, which JRuby 9.3 does not support
           - jruby_version: '9.3.15.0'
-            java_version: '8'
-            appraisal: 'rails72' # Requires Ruby 3.1 compatibility, which JRuby 9.3 does not support
-          - jruby_version: '9.3.15.0'
-            java_version: '11'
-            appraisal: 'rails70' # Requires Ruby 2.7 compatibility, which JRuby 9.3 does not support
-          - jruby_version: '9.3.15.0'
-            java_version: '11'
-            appraisal: 'rails71' # Requires Ruby 2.7 compatibility, which JRuby 9.3 does not support
-          - jruby_version: '9.3.15.0'
-            java_version: '11'
-            appraisal: 'rails72' # Requires Ruby 3.1 compatibility, which JRuby 9.3 does not support
-          - jruby_version: '9.3.15.0'
-            java_version: '17'
-            appraisal: 'rails70' # Requires Ruby 2.7 compatibility, which JRuby 9.3 does not support
-          - jruby_version: '9.3.15.0'
-            java_version: '17'
-            appraisal: 'rails71' # Requires Ruby 2.7 compatibility, which JRuby 9.3 does not support
-          - jruby_version: '9.3.15.0'
-            java_version: '17'
-            appraisal: 'rails72' # Requires Ruby 3.1 compatibility, which JRuby 9.3 does not support
-          - jruby_version: '9.3.15.0'
-            java_version: '21'
-            appraisal: 'rails70' # Requires Ruby 2.7 compatibility, which JRuby 9.3 does not support
-          - jruby_version: '9.3.15.0'
-            java_version: '21'
-            appraisal: 'rails71' # Requires Ruby 2.7 compatibility, which JRuby 9.3 does not support
-          - jruby_version: '9.3.15.0'
-            java_version: '21'
             appraisal: 'rails72' # Requires Ruby 3.1 compatibility, which JRuby 9.3 does not support
           - jruby_version: '10.0.0.1'
             java_version: '8' # JRuby 10 requires Java 21
@@ -112,7 +87,7 @@ jobs:
           cache: maven
 
       - name: Setup JRuby
-        uses: ruby/setup-ruby@e34163cd15f4bb403dcd72d98e295997e6a55798 # v1.238.0
+        uses: ruby/setup-ruby@13e7a03dc3ac6c3798f4570bfead2aed4d96abfb # v1.244.0
         with:
           ruby-version: jruby-${{ matrix.jruby_version }}
           bundler-cache: 'false' # Need to install later so we can vary from Gemfile.lock as required for JRuby version compatibility

--- a/Gemfile
+++ b/Gemfile
@@ -12,5 +12,5 @@ group :development do
   gem 'appraisal', :require => nil
 end
 
-gem 'rake', '~> 13.2', :group => :test, :require => nil
+gem 'rake', '~> 13.3', :group => :test, :require => nil
 gem 'rspec', :group => :test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,21 +6,21 @@ GEM
       rake
       thor (>= 0.14.0)
     diff-lcs (1.6.2)
-    rack (2.2.15)
-    rake (13.2.1)
-    rspec (3.13.0)
+    rack (2.2.16)
+    rake (13.3.0)
+    rspec (3.13.1)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.3)
+    rspec-core (3.13.4)
       rspec-support (~> 3.13.0)
-    rspec-expectations (3.13.4)
+    rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.4)
+    rspec-mocks (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-support (3.13.3)
+    rspec-support (3.13.4)
     thor (1.3.2)
 
 PLATFORMS
@@ -33,7 +33,7 @@ PLATFORMS
 DEPENDENCIES
   appraisal
   rack (~> 2.2)
-  rake (~> 13.2)
+  rake (~> 13.3)
   rspec
 
 BUNDLED WITH

--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+## 1.2.4 (UNRELEASED)
+
+- update (bundled) rack to 2.2.16
+
 ## 1.2.3
 
 - avoid warnings due usage of `File.exists?`

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   </description>
 
   <properties>
-    <jruby.version>9.4.12.0</jruby.version>
+    <jruby.version>9.4.12.1</jruby.version>
     <jruby.maven.plugins.version>3.0.5</jruby.maven.plugins.version>
     <gem.home>${project.build.directory}/rubygems</gem.home>
     <slf4j.version>2.0.17</slf4j.version>


### PR DESCRIPTION
- Cleans up ignore rules to avoid dependabot PRs for likely API-breaking dependencies and reduce PR noise
  - This should automatically clean up all the PRs dependabot created here that otherwise need review  
- Avoids time-consuming double-builds on pushes to PR branches by building only on direct push to `master` and `release`-like branches
- Simplify workflow matrix exclusion rules for JRuby 9.3
- Bumps minor/patch dependency versions for GHA and other dependencies

If you could take a look @kares - just cleaning up after the cherry pick from my earlier JRuby 10 branch. 1.2.x compatible.

Probably doesn't need a release unless this [2.2.16 fix for CGI::Cookie](https://github.com/rack/rack/blob/main/CHANGELOG.md#2216---2025-05-22) is relevant for jruby-rack.