### PR TITLE
[v1.3.x] Drop JRuby 9.3 testing, bumping to Java 11 minimum with Servlet 3.1 and 4.0 compilation compatibility

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   # Default versions for canonical release build
-  DEFAULT_JAVA_VERSION: '8'
+  DEFAULT_JAVA_VERSION: '11'
   DEFAULT_JRUBY_VERSION: '9.4.13.0' # Should match pom.xml <jruby.version> property (AND a version inside the test matrix)
 
 jobs:
@@ -18,11 +18,9 @@ jobs:
 
     strategy:
       matrix:
-        jruby_version: [ '9.3.15.0', '9.4.13.0', '10.0.0.1' ]
-        java_version: [ '8', '11', '17', '21' ]
+        jruby_version: [ '9.4.13.0', '10.0.0.1' ]
+        java_version: [ '11', '17', '21' ]
         exclude:
-          - jruby_version: '10.0.0.1'
-            java_version: '8' # JRuby 10 requires Java 21
           - jruby_version: '10.0.0.1'
             java_version: '11' # JRuby 10 requires Java 21
           - jruby_version: '10.0.0.1'
@@ -54,22 +52,12 @@ jobs:
 
     strategy:
       matrix:
-        jruby_version: [ '9.3.15.0', '9.4.13.0', '10.0.0.1' ]
-        java_version: [ '8', '11', '17', '21' ]
+        jruby_version: [ '9.4.13.0', '10.0.0.1' ]
+        java_version: [ '11', '17', '21' ]
         appraisal: [ 'rails50', 'rails52', 'rails60', 'rails61', 'rails70', 'rails71', 'rails72', 'rails80' ]
         exclude:
-          - jruby_version: '9.3.15.0'
-            appraisal: 'rails70' # Requires Ruby 2.7 compatibility, which JRuby 9.3 does not support
-          - jruby_version: '9.3.15.0'
-            appraisal: 'rails71' # Requires Ruby 2.7 compatibility, which JRuby 9.3 does not support
-          - jruby_version: '9.3.15.0'
-            appraisal: 'rails72' # Requires Ruby 3.1 compatibility, which JRuby 9.3 does not support
-          - jruby_version: '9.3.15.0'
-            appraisal: 'rails80' # Requires Ruby 3.4 compatibility, which JRuby 9.3 does not support
           - jruby_version: '9.4.13.0'
             appraisal: 'rails80' # Requires Ruby 3.4 compatibility, which JRuby 9.4 does not support
-          - jruby_version: '10.0.0.1'
-            java_version: '8' # JRuby 10 requires Java 21
           - jruby_version: '10.0.0.1'
             java_version: '11' # JRuby 10 requires Java 21
           - jruby_version: '10.0.0.1'
@@ -95,7 +83,7 @@ jobs:
         with:
           ruby-version: jruby-${{ matrix.jruby_version }}
           bundler-cache: 'false' # Need to install later so we can vary from Gemfile.lock as required for JRuby version compatibility
-          bundler: ${{ startsWith(matrix.jruby_version, '9.3') && '2.3.27' || 'Gemfile.lock' }}
+          bundler: 'Gemfile.lock'
 
       - name: Run appraisal for ${{ matrix.appraisal }}
         run: bundle install && bundle exec rake spec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,6 @@ GEM
     thor (1.3.2)
 
 PLATFORMS
-  universal-java-1.8
   universal-java-11
   universal-java-17
   universal-java-21

--- a/History.md
+++ b/History.md
@@ -3,6 +3,8 @@
 - Adds basic compatibility with JRuby 10.0
 - Drop unnecessary jruby.compat.version and RackConfig.getCompatVersion() API
 - Drop JMS support
+- Drop support for JRuby 9.3
+- Require Java 11 or later
 - update (bundled) rack to 2.2.17
 
 ## 1.2.4 (UNRELEASED)

--- a/History.md
+++ b/History.md
@@ -1,10 +1,11 @@
 ## 1.3.0 (UNRELEASED) 
 
+- Require Java 11 or later
+- Support Javax Servlet API 4.0 (JEE 8)
 - Adds basic compatibility with JRuby 10.0
+- Drop support for JRuby 9.3
 - Drop unnecessary jruby.compat.version and RackConfig.getCompatVersion() API
 - Drop JMS support
-- Drop support for JRuby 9.3
-- Require Java 11 or later
 - update (bundled) rack to 2.2.17
 
 ## 1.2.4 (UNRELEASED)

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ current stable 1.1.x releases.**
 ## Compatibility
 
 JRuby-Rack 1.3.x
-- aims to be compatible with JRuby 9.3 -> 10.0 and their supported JDK versions
-- supports any container compatible with Java Servlet 3.0 API
+- aims to be compatible with JRuby 9.4 -> 10.0 and Java 11+
+- supports any container compatible with Java Servlet 4.0 API
 
 JRuby-Rack 1.2.x
 - compatible with JRuby 9.3 -> 9.4 and their supported JDK versions

--- a/gemfiles/rails50.gemfile.lock
+++ b/gemfiles/rails50.gemfile.lock
@@ -138,7 +138,6 @@ GEM
     websocket-extensions (0.1.5)
 
 PLATFORMS
-  universal-java-1.8
   universal-java-11
   universal-java-17
   universal-java-21

--- a/gemfiles/rails52.gemfile.lock
+++ b/gemfiles/rails52.gemfile.lock
@@ -146,7 +146,6 @@ GEM
     websocket-extensions (0.1.5)
 
 PLATFORMS
-  universal-java-1.8
   universal-java-11
   universal-java-17
   universal-java-21

--- a/gemfiles/rails60.gemfile.lock
+++ b/gemfiles/rails60.gemfile.lock
@@ -162,7 +162,6 @@ GEM
     zeitwerk (2.7.3)
 
 PLATFORMS
-  universal-java-1.8
   universal-java-11
   universal-java-17
   universal-java-21

--- a/gemfiles/rails61.gemfile.lock
+++ b/gemfiles/rails61.gemfile.lock
@@ -165,7 +165,6 @@ GEM
     zeitwerk (2.7.3)
 
 PLATFORMS
-  universal-java-1.8
   universal-java-11
   universal-java-17
   universal-java-21

--- a/gemfiles/rails70.gemfile.lock
+++ b/gemfiles/rails70.gemfile.lock
@@ -162,7 +162,6 @@ GEM
     zeitwerk (2.7.3)
 
 PLATFORMS
-  universal-java-1.8
   universal-java-11
   universal-java-17
   universal-java-21

--- a/gemfiles/rails71.gemfile.lock
+++ b/gemfiles/rails71.gemfile.lock
@@ -205,7 +205,6 @@ GEM
     zeitwerk (2.7.3)
 
 PLATFORMS
-  universal-java-1.8
   universal-java-11
   universal-java-17
   universal-java-21

--- a/gemfiles/rails72.gemfile.lock
+++ b/gemfiles/rails72.gemfile.lock
@@ -199,7 +199,6 @@ GEM
     zeitwerk (2.7.3)
 
 PLATFORMS
-  universal-java-1.8
   universal-java-11
   universal-java-17
   universal-java-21

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <jruby.maven.plugins.version>3.0.6</jruby.maven.plugins.version>
     <gem.home>${project.build.directory}/rubygems</gem.home>
     <slf4j.version>2.0.17</slf4j.version>
-    <spring.version>4.3.30.RELEASE</spring.version>
+    <spring.version>5.3.39</spring.version>
   </properties>
 
   <issueManagement>
@@ -99,9 +99,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>3.0.1</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>4.0.4</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -199,8 +199,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.14.0</version>
         <configuration>
-          <source>8</source>
-          <target>8</target>
+          <source>11</source>
+          <target>11</target>
           <showDeprecation>true</showDeprecation>
           <showWarnings>true</showWarnings>
         </configuration>

--- a/src/main/java/org/jruby/rack/servlet/DefaultServletRackContext.java
+++ b/src/main/java/org/jruby/rack/servlet/DefaultServletRackContext.java
@@ -271,56 +271,96 @@ public class DefaultServletRackContext implements ServletRackContext {
     }
 
     @Override
+    public String getVirtualServerName() {
+        return context.getVirtualServerName();
+    }
+
+    @Override
+    public int getSessionTimeout() {
+        return context.getSessionTimeout();
+    }
+
+    @Override
+    public void setSessionTimeout(int sessionTimeout) {
+        context.setSessionTimeout(sessionTimeout);
+    }
+
+    @Override
+    public String getRequestCharacterEncoding() {
+        return context.getRequestCharacterEncoding();
+    }
+
+    @Override
+    public void setRequestCharacterEncoding(String encoding) {
+        context.setRequestCharacterEncoding(encoding);
+    }
+
+    @Override
+    public String getResponseCharacterEncoding() {
+        return context.getResponseCharacterEncoding();
+    }
+
+    @Override
+    public void setResponseCharacterEncoding(String encoding) {
+        context.setResponseCharacterEncoding(encoding);
+    }
+
+    @Override
     public <T extends Servlet> T createServlet(Class<T> type) throws ServletException {
         return context.createServlet(type);
     }
 
-    @Override // 3.0 in method signature
+    @Override
     public ServletRegistration.Dynamic addServlet(String servletName, String className) throws IllegalArgumentException, IllegalStateException {
         return context.addServlet(servletName, className);
     }
 
-    @Override // 3.0 in method signature
+    @Override
     public ServletRegistration.Dynamic addServlet(String servletName, Servlet servlet) throws IllegalArgumentException, IllegalStateException {
         return context.addServlet(servletName, servlet);
     }
 
-    @Override // 3.0 in method signature
+    @Override
     public ServletRegistration.Dynamic addServlet(String servletName, Class<? extends Servlet> servletClass) throws IllegalArgumentException, IllegalStateException {
         return context.addServlet(servletName, servletClass);
     }
 
-    @Override // 3.0 in method signature
+    @Override
+    public ServletRegistration.Dynamic addJspFile(String servletName, String jspFile) {
+        return context.addJspFile(servletName, jspFile);
+    }
+
+    @Override
     public ServletRegistration getServletRegistration(String servletName) {
         return context.getServletRegistration(servletName);
     }
 
-    @Override // 3.0 in method signature
+    @Override
     public Map<String, ? extends ServletRegistration> getServletRegistrations() {
         return context.getServletRegistrations();
     }
 
-    @Override // 3.0 in method signature
+    @Override
     public <T extends Filter> T createFilter(Class<T> type) throws ServletException {
         return context.createFilter(type);
     }
 
-    @Override // 3.0 in method signature
+    @Override
     public FilterRegistration.Dynamic addFilter(String filterName, String className) throws IllegalArgumentException, IllegalStateException {
         return context.addFilter(filterName, className);
     }
 
-    @Override // 3.0 in method signature
+    @Override
     public FilterRegistration.Dynamic addFilter(String filterName, Filter filter) throws IllegalArgumentException, IllegalStateException {
         return context.addFilter(filterName, filter);
     }
 
-    @Override // 3.0 in method signature
+    @Override
     public FilterRegistration.Dynamic addFilter(String filterName, Class<? extends Filter> filterClass) throws IllegalArgumentException, IllegalStateException {
         return context.addFilter(filterName, filterClass);
     }
 
-    @Override // 3.0 in method signature
+    @Override
     public FilterRegistration getFilterRegistration(String filterName) {
         return context.getFilterRegistration(filterName);
     }
@@ -350,7 +390,7 @@ public class DefaultServletRackContext implements ServletRackContext {
         return context.createListener(listenerClass);
     }
 
-    @Override // 3.0 in method signature
+    @Override
     public SessionCookieConfig getSessionCookieConfig() {
         return context.getSessionCookieConfig();
     }
@@ -370,7 +410,7 @@ public class DefaultServletRackContext implements ServletRackContext {
         return context.getEffectiveSessionTrackingModes();
     }
 
-    @Override // 3.0 in method signature
+    @Override
     public JspConfigDescriptor getJspConfigDescriptor() {
         return context.getJspConfigDescriptor();
     }

--- a/src/main/java/org/jruby/rack/servlet/ResponseCapture.java
+++ b/src/main/java/org/jruby/rack/servlet/ResponseCapture.java
@@ -19,6 +19,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpServletResponseWrapper;
@@ -166,7 +167,17 @@ public class ResponseCapture extends HttpServletResponseWrapper {
             // backwards compatibility with isError() :
             return new ServletOutputStream() {
                 @Override
-                public void write(int b) throws IOException {
+                public boolean isReady() {
+                    return true;
+                }
+
+                @Override
+                public void setWriteListener(WriteListener writeListener) {
+                    // swallow listeners, as we're also going to swallow output
+                }
+
+                @Override
+                public void write(int b) {
                     // swallow output, because we're going to discard it
                 }
             };

--- a/src/main/java/org/jruby/rack/servlet/RewindableInputStream.java
+++ b/src/main/java/org/jruby/rack/servlet/RewindableInputStream.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 
+import javax.servlet.ReadListener;
 import javax.servlet.ServletInputStream;
 
 /**
@@ -401,5 +402,27 @@ public class RewindableInputStream extends ServletInputStream {
     public int getMaximumBufferSize() {
         return bufferMax;
     }
-    
+
+    @Override
+    public boolean isFinished() {
+        try {
+            return input.available() <= 0;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public boolean isReady() {
+        try {
+            return input.available() >= 0;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void setReadListener(ReadListener readListener) {
+        throw new UnsupportedOperationException("readListener not supported");
+    }
 }

--- a/src/main/java/org/jruby/rack/servlet/ServletRackIncludedResponse.java
+++ b/src/main/java/org/jruby/rack/servlet/ServletRackIncludedResponse.java
@@ -16,6 +16,7 @@ import java.io.UnsupportedEncodingException;
 
 import javax.servlet.ServletOutputStream;
 import javax.servlet.ServletResponse;
+import javax.servlet.WriteListener;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpServletResponseWrapper;
 
@@ -158,7 +159,7 @@ public class ServletRackIncludedResponse extends HttpServletResponseWrapper {
 	 */
 	private static class ByteArrayServletOutputStream extends ServletOutputStream {
 		
-		private final static String LINE_SEPARATOR = System.getProperty("line.separator");
+		private final static String LINE_SEPARATOR = System.lineSeparator();
 		private final DataOutputStream dataOutputStream;
 		private final String charSet;
 		
@@ -166,6 +167,26 @@ public class ServletRackIncludedResponse extends HttpServletResponseWrapper {
 			super();
 			this.dataOutputStream = new DataOutputStream(byteOutputStream);
 			this.charSet = charSet;
+		}
+
+		@Override
+		public void write(byte[] b, int off, int len) throws IOException {
+			dataOutputStream.write(b, off, len);
+		}
+
+		@Override
+		public void write(byte[] b) throws IOException {
+			dataOutputStream.write(b);
+		}
+
+		@Override
+		public void write(int i) throws IOException {
+			dataOutputStream.write(i);
+		}
+
+		@Override
+		public void print(String s) throws IOException {
+			dataOutputStream.write(s.getBytes(charSet));
 		}
 
 		@Override
@@ -179,16 +200,6 @@ public class ServletRackIncludedResponse extends HttpServletResponseWrapper {
 		}
 
 		@Override
-		public void print(double d) throws IOException {
-			dataOutputStream.writeDouble(d);
-		}
-
-		@Override
-		public void print(float f) throws IOException {
-			dataOutputStream.writeFloat(f);
-		}
-
-		@Override
 		public void print(int i) throws IOException {
 			dataOutputStream.write(i);
 		}
@@ -199,13 +210,23 @@ public class ServletRackIncludedResponse extends HttpServletResponseWrapper {
 		}
 
 		@Override
-		public void print(String s) throws IOException {
-			dataOutputStream.write(s.getBytes(charSet));
+		public void print(float f) throws IOException {
+			dataOutputStream.writeFloat(f);
+		}
+
+		@Override
+		public void print(double d) throws IOException {
+			dataOutputStream.writeDouble(d);
 		}
 
 		@Override
 		public void println() throws IOException {
 			dataOutputStream.write(LINE_SEPARATOR.getBytes(charSet));
+		}
+
+		@Override
+		public void println(String s) throws IOException {
+			print(s);
 		}
 
 		@Override
@@ -217,18 +238,6 @@ public class ServletRackIncludedResponse extends HttpServletResponseWrapper {
 		@Override
 		public void println(char c) throws IOException {
 			print(c);
-			println();
-		}
-
-		@Override
-		public void println(double d) throws IOException {
-			print(d);
-			println();
-		}
-
-		@Override
-		public void println(float f) throws IOException {
-			print(f);
 			println();
 		}
 
@@ -245,23 +254,25 @@ public class ServletRackIncludedResponse extends HttpServletResponseWrapper {
 		}
 
 		@Override
-		public void println(String s) throws IOException {
-			print(s);
+		public void println(float f) throws IOException {
+			print(f);
+			println();
 		}
 
 		@Override
-		public void write(byte[] b, int off, int len) throws IOException {
-			dataOutputStream.write(b, off, len);
+		public void println(double d) throws IOException {
+			print(d);
+			println();
 		}
 
 		@Override
-		public void write(byte[] b) throws IOException {
-			dataOutputStream.write(b);
+		public boolean isReady() {
+			return true;
 		}
 
 		@Override
-		public void write(int i) throws IOException {
-			dataOutputStream.write(i);
+		public void setWriteListener(WriteListener writeListener) {
+			throw new UnsupportedOperationException("writeListener not supported");
 		}
 	}
 }


### PR DESCRIPTION
- Fixes #285
- Increases baseline to Java 11
- Bumps testing to be against/with Spring 5.3 which is the last version to target/use javax Servlent API 3.0
- Adds compatibility with Servlet 3.1 and Servlet 4.0 APIs (although I have personally found in practice `1.1.x` and `1.2.x` work fine in Servlet 4.0 environments such as embedded Jetty which appear to not use/require the new APIs)