### PR TITLE
Migrate to publishing via new Sonatype Central publishing portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ package and push the .jar every time a commit changes a source file).
 
 ## Releasing
 
-* Make sure auth is configured for "ossrh" repository ID in your .m2/settings.xml
+* Make sure auth is configured for "central" repository ID in your .m2/settings.xml
 * Update the version in src/main/ruby/jruby/rack/version.rb to the release version
 * mvn release:prepare
 * mvn release:perform (possibly with -DuseReleaseProfile=false due to Javadoc doclint failures for now)

--- a/pom.xml
+++ b/pom.xml
@@ -31,17 +31,6 @@
     <url>https://github.com/jruby/jruby-rack/issues</url>
   </issueManagement>
 
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
-
   <scm>
     <connection>scm:git:git://github.com/jruby/jruby-rack.git</connection>
     <developerConnection>scm:git:git@github.com:jruby/jruby-rack.git</developerConnection>
@@ -284,14 +273,13 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.8.0</version>
         <extensions>true</extensions>
         <configuration>
-           <serverId>ossrh</serverId>
-           <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-           <autoReleaseAfterClose>false</autoReleaseAfterClose>
+          <publishingServerId>central</publishingServerId>
+          <autoPublish>true</autoPublish>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
I believe jruby-rack and jruby share a namespace, and jruby was migrated in https://github.com/jruby/jruby/commit/bea540848c9bb559cfd73f32c2044d8b557f8264 so presume this needs to be done here too.

Have assumed the same `central` ID for creds as JRuby Core is using, in contrast with the earlier `ossrh` credential identifier.