### PR TITLE
Fix Rails 7.1 CSRF token support

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,9 +2,9 @@ name: Java CI
 
 on:
   push:
-    branches: [ "master", "*release*", "*stable*" ]
+    branches: [ "master", "*-stable" ]
   pull_request:
-    branches: [ "master", "*release*", "*stable*" ]
+    branches: [ "master", "*-stable" ]
 
 env:
   # Default versions for canonical release build

--- a/History.md
+++ b/History.md
@@ -4,14 +4,16 @@
 - Drop unnecessary jruby.compat.version and RackConfig.getCompatVersion() API
 - Drop JMS support
 - update (bundled) rack to 2.2.17
+- Fix Rails 7.1 CSRF protection when working with `JavaServletStore` sessions
 
 ## 1.2.4 (UNRELEASED)
 
-- update (bundled) rack to 2.2.16
+- update (bundled) rack to 2.2.17
+- Fix Rails 7.1 CSRF protection when working with `JavaServletStore` sessions
 
 ## 1.2.3
 
-- avoid warnings due usage of `File.exists?`
+- avoid warnings due to usage of `File.exists?`
 - Fix Rails 7.1 compatibility by ensuring active_support is required before railtie
 - Workaround logger require issues with concurrent-ruby 1.3.5 and older Rails versions
 - Workaround NameError frozen string literal issues with JRuby 9.3 and Rails 5.2/6.0

--- a/gemfiles/rails50.gemfile.lock
+++ b/gemfiles/rails50.gemfile.lock
@@ -65,7 +65,7 @@ GEM
     method_source (1.1.0)
     mini_mime (1.1.5)
     minitest (5.25.5)
-    net-imap (0.5.8)
+    net-imap (0.5.9)
       date
       net-protocol
     net-pop (0.1.2)
@@ -78,7 +78,7 @@ GEM
     nokogiri (1.18.8-java)
       racc (~> 1.4)
     racc (1.8.1-java)
-    rack (2.2.16)
+    rack (2.2.17)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (5.0.7.2)
@@ -111,7 +111,7 @@ GEM
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.4)
+    rspec-core (3.13.5)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)

--- a/gemfiles/rails52.gemfile.lock
+++ b/gemfiles/rails52.gemfile.lock
@@ -71,7 +71,7 @@ GEM
     method_source (1.1.0)
     mini_mime (1.1.5)
     minitest (5.25.5)
-    net-imap (0.5.8)
+    net-imap (0.5.9)
       date
       net-protocol
     net-pop (0.1.2)
@@ -84,7 +84,7 @@ GEM
     nokogiri (1.18.8-java)
       racc (~> 1.4)
     racc (1.8.1-java)
-    rack (2.2.16)
+    rack (2.2.17)
     rack-test (2.2.0)
       rack (>= 1.3)
     rails (5.2.8.1)
@@ -118,7 +118,7 @@ GEM
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.4)
+    rspec-core (3.13.5)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)

--- a/gemfiles/rails60.gemfile.lock
+++ b/gemfiles/rails60.gemfile.lock
@@ -84,7 +84,7 @@ GEM
     method_source (1.1.0)
     mini_mime (1.1.5)
     minitest (5.25.5)
-    net-imap (0.5.8)
+    net-imap (0.5.9)
       date
       net-protocol
     net-pop (0.1.2)
@@ -97,7 +97,7 @@ GEM
     nokogiri (1.18.8-java)
       racc (~> 1.4)
     racc (1.8.1-java)
-    rack (2.2.16)
+    rack (2.2.17)
     rack-test (2.2.0)
       rack (>= 1.3)
     rails (6.0.6.1)
@@ -133,7 +133,7 @@ GEM
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.4)
+    rspec-core (3.13.5)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -159,7 +159,7 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.7.3)
+    zeitwerk (2.6.18)
 
 PLATFORMS
   universal-java-1.8

--- a/gemfiles/rails61.gemfile.lock
+++ b/gemfiles/rails61.gemfile.lock
@@ -88,7 +88,7 @@ GEM
     method_source (1.1.0)
     mini_mime (1.1.5)
     minitest (5.25.5)
-    net-imap (0.5.8)
+    net-imap (0.5.9)
       date
       net-protocol
     net-pop (0.1.2)
@@ -101,7 +101,7 @@ GEM
     nokogiri (1.18.8-java)
       racc (~> 1.4)
     racc (1.8.1-java)
-    rack (2.2.16)
+    rack (2.2.17)
     rack-test (2.2.0)
       rack (>= 1.3)
     rails (6.1.7.10)
@@ -137,7 +137,7 @@ GEM
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.4)
+    rspec-core (3.13.5)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -162,7 +162,7 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.7.3)
+    zeitwerk (2.6.18)
 
 PLATFORMS
   universal-java-1.8

--- a/gemfiles/rails70.gemfile.lock
+++ b/gemfiles/rails70.gemfile.lock
@@ -93,7 +93,7 @@ GEM
     method_source (1.1.0)
     mini_mime (1.1.5)
     minitest (5.25.5)
-    net-imap (0.5.8)
+    net-imap (0.5.9)
       date
       net-protocol
     net-pop (0.1.2)
@@ -106,7 +106,7 @@ GEM
     nokogiri (1.18.8-java)
       racc (~> 1.4)
     racc (1.8.1-java)
-    rack (2.2.16)
+    rack (2.2.17)
     rack-test (2.2.0)
       rack (>= 1.3)
     rails (7.0.8.7)
@@ -142,7 +142,7 @@ GEM
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.4)
+    rspec-core (3.13.5)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -159,7 +159,7 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.7.3)
+    zeitwerk (2.6.18)
 
 PLATFORMS
   universal-java-1.8

--- a/gemfiles/rails71.gemfile.lock
+++ b/gemfiles/rails71.gemfile.lock
@@ -84,15 +84,17 @@ GEM
       thor (>= 0.14.0)
     base64 (0.3.0)
     benchmark (0.4.1)
-    bigdecimal (3.2.1-java)
+    bigdecimal (3.2.2-java)
     builder (3.3.0)
+    cgi (0.5.0-java)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
     date (3.4.1-java)
     diff-lcs (1.6.2)
     drb (2.2.3)
-    erb (5.0.1-java)
+    erb (4.0.4-java)
+      cgi (>= 0.3.3)
     erubi (1.13.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -117,7 +119,7 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.5)
     mutex_m (0.3.0)
-    net-imap (0.5.8)
+    net-imap (0.5.9)
       date
       net-protocol
     net-pop (0.1.2)
@@ -136,7 +138,7 @@ GEM
       date
       jar-dependencies (>= 0.1.7)
     racc (1.8.1-java)
-    rack (2.2.16)
+    rack (2.2.17)
     rack-session (1.0.2)
       rack (< 3)
     rack-test (2.2.0)
@@ -174,7 +176,7 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rake (13.3.0)
-    rdoc (6.14.0)
+    rdoc (6.14.2)
       erb
       psych (>= 4.0.0)
     reline (0.6.1)
@@ -183,7 +185,7 @@ GEM
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.4)
+    rspec-core (3.13.5)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -202,7 +204,7 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.7.3)
+    zeitwerk (2.6.18)
 
 PLATFORMS
   universal-java-1.8

--- a/gemfiles/rails72.gemfile.lock
+++ b/gemfiles/rails72.gemfile.lock
@@ -78,15 +78,17 @@ GEM
       thor (>= 0.14.0)
     base64 (0.3.0)
     benchmark (0.4.1)
-    bigdecimal (3.2.1-java)
+    bigdecimal (3.2.2-java)
     builder (3.3.0)
+    cgi (0.5.0-java)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
     date (3.4.1-java)
     diff-lcs (1.6.2)
     drb (2.2.3)
-    erb (5.0.1-java)
+    erb (4.0.4-java)
+      cgi (>= 0.3.3)
     erubi (1.13.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -110,7 +112,7 @@ GEM
     marcel (1.0.4)
     mini_mime (1.1.5)
     minitest (5.25.5)
-    net-imap (0.5.8)
+    net-imap (0.5.9)
       date
       net-protocol
     net-pop (0.1.2)
@@ -129,7 +131,7 @@ GEM
       date
       jar-dependencies (>= 0.1.7)
     racc (1.8.1-java)
-    rack (2.2.16)
+    rack (2.2.17)
     rack-session (1.0.2)
       rack (< 3)
     rack-test (2.2.0)
@@ -167,7 +169,7 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rake (13.3.0)
-    rdoc (6.14.0)
+    rdoc (6.14.2)
       erb
       psych (>= 4.0.0)
     reline (0.6.1)
@@ -176,7 +178,7 @@ GEM
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.4)
+    rspec-core (3.13.5)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -196,7 +198,7 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.7.3)
+    zeitwerk (2.6.18)
 
 PLATFORMS
   universal-java-1.8

--- a/gemfiles/rails80.gemfile.lock
+++ b/gemfiles/rails80.gemfile.lock
@@ -78,7 +78,7 @@ GEM
       thor (>= 0.14.0)
     base64 (0.3.0)
     benchmark (0.4.1)
-    bigdecimal (3.2.1-java)
+    bigdecimal (3.2.2-java)
     builder (3.3.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
@@ -110,7 +110,7 @@ GEM
     marcel (1.0.4)
     mini_mime (1.1.5)
     minitest (5.25.5)
-    net-imap (0.5.8)
+    net-imap (0.5.9)
       date
       net-protocol
     net-pop (0.1.2)
@@ -129,7 +129,7 @@ GEM
       date
       jar-dependencies (>= 0.1.7)
     racc (1.8.1-java)
-    rack (2.2.16)
+    rack (2.2.17)
     rack-session (1.0.2)
       rack (< 3)
     rack-test (2.2.0)
@@ -167,7 +167,7 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rake (13.3.0)
-    rdoc (6.14.0)
+    rdoc (6.14.2)
       erb
       psych (>= 4.0.0)
     reline (0.6.1)
@@ -176,7 +176,7 @@ GEM
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.4)
+    rspec-core (3.13.5)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)


### PR DESCRIPTION
Fixes #295 by replicating logic below from Rails `abstract_store` which propagates the CSRF token from the request environment only during `commit_session`.

https://github.com/rails/rails/commit/f2c66ce392016efd49816cd6fdc9f174271a0321#diff-5207bc67aa19cddd5a4997dec3c69fa4ba541750fbd881c6f7e30b27df9ea9ddR70-R73

https://github.com/rails/rails/commit/f2c66ce392016efd49816cd6fdc9f174271a0321#diff-5f81b06a0e3051b576daee16c960b21e715a6cc26d97d020c546d2fa697c9bc6R345-R348

I couldn't really find an alternate approach that seemed better, e.g by re-using the Rails code directly (either `Request.commit_csrf_token` or `AbstractStore.commit_session`). This is because in the jruby-rack case, the request object that the store sees appears to be a `Rack::Request` whereas the Rails `abstract_store` code expects an `ActionDispatch::Request` so `req.commit_csrf_token` is not defined. I couldn't find a way to cleanly access the `ActionDIspatch::Request` from the `Rack::Request` either.

How this all works earlier is a bit confusing for me, and the current approach is obviously somewhat coupled to the current Rails 7.1/7.2/8.0 behaviour, but it seemed possibly OK given the otherwise deep integration we are dealing with here? The way they have implemented this in Rails doesn't seem great to me due to the need for `AbstractStore` to now understand when to invoke a special CSRF hook, so this has created a bit more coupling for us.

Additional minor technical changes
- Changes sessions to inherit from non-deprecated `::Rack::Session::Abstract::Persisted` to fix warnings
- Avoid unnecessarily overriding `context(env)` and align signatures for overridden functions with Rack 2.2.x for easy of understanding (the only supported Rack version for jruby-rack 1.2)
- Prefer newer impl names from `::Persisted` rather than legacy `::ID` (`delete_session` rather than `destroy_session`, `write_session` rather than `set_session`)
- corrects appraisal lock files for running on older jruby versions