### PR TITLE
[backport 1.2.x] Migrate publishing to go via new Sonatype Central publishing portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ package and push the .jar every time a commit changes a source file).
 
 ## Releasing
 
-* Make sure auth is configured for "ossrh" repository ID in your .m2/settings.xml
+* Make sure auth is configured for "central" repository ID in your .m2/settings.xml
 * Update the version in src/main/ruby/jruby/rack/version.rb to the release version
 * mvn release:prepare
 * mvn release:perform (possibly with -DuseReleaseProfile=false due to Javadoc doclint failures for now)

--- a/pom.xml
+++ b/pom.xml
@@ -31,17 +31,6 @@
     <url>https://github.com/jruby/jruby-rack/issues</url>
   </issueManagement>
 
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
-
   <scm>
     <connection>scm:git:git://github.com/jruby/jruby-rack.git</connection>
     <developerConnection>scm:git:git@github.com:jruby/jruby-rack.git</developerConnection>
@@ -290,14 +279,13 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.8.0</version>
         <extensions>true</extensions>
         <configuration>
-           <serverId>ossrh</serverId>
-           <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-           <autoReleaseAfterClose>false</autoReleaseAfterClose>
+          <publishingServerId>central</publishingServerId>
+          <autoPublish>true</autoPublish>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Backports #294 to v1.2.x