### PR TITLE
Test against JRuby 10.0.1.0

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,12 +18,12 @@ jobs:
 
     strategy:
       matrix:
-        jruby_version: [ '9.4.13.0', '10.0.0.1' ]
+        jruby_version: [ '9.4.13.0', '10.0.1.0' ]
         java_version: [ '11', '17', '21' ]
         exclude:
-          - jruby_version: '10.0.0.1'
+          - jruby_version: '10.0.1.0'
             java_version: '11' # JRuby 10 requires Java 21
-          - jruby_version: '10.0.0.1'
+          - jruby_version: '10.0.1.0'
             java_version: '17' # JRuby 10 requires Java 21
       fail-fast: false
 
@@ -52,15 +52,15 @@ jobs:
 
     strategy:
       matrix:
-        jruby_version: [ '9.4.13.0', '10.0.0.1' ]
+        jruby_version: [ '9.4.13.0', '10.0.1.0' ]
         java_version: [ '11', '17', '21' ]
         appraisal: [ 'rails50', 'rails52', 'rails60', 'rails61', 'rails70', 'rails71', 'rails72', 'rails80' ]
         exclude:
           - jruby_version: '9.4.13.0'
             appraisal: 'rails80' # Requires Ruby 3.4 compatibility, which JRuby 9.4 does not support
-          - jruby_version: '10.0.0.1'
+          - jruby_version: '10.0.1.0'
             java_version: '11' # JRuby 10 requires Java 21
-          - jruby_version: '10.0.0.1'
+          - jruby_version: '10.0.1.0'
             java_version: '17' # JRuby 10 requires Java 21
       fail-fast: false
 
@@ -79,7 +79,7 @@ jobs:
           cache: maven
 
       - name: Setup JRuby
-        uses: ruby/setup-ruby@472790540115ce5bd69d399a020189a8c87d641f # v1.247.0
+        uses: ruby/setup-ruby@a9bfc2ecf3dd40734a9418f89a7e9d484c32b990 # v1.248.0
         with:
           ruby-version: jruby-${{ matrix.jruby_version }}
           bundler-cache: 'false' # Need to install later so we can vary from Gemfile.lock as required for JRuby version compatibility

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,3 @@ DEPENDENCIES
   rack (~> 2.2)
   rake (~> 13.3)
   rspec
-
-BUNDLED WITH
-   2.6.3

--- a/gemfiles/rails50.gemfile.lock
+++ b/gemfiles/rails50.gemfile.lock
@@ -148,6 +148,3 @@ DEPENDENCIES
   rails (~> 5.0.0)
   rake (~> 13.3)
   rspec
-
-BUNDLED WITH
-   2.6.3

--- a/gemfiles/rails52.gemfile.lock
+++ b/gemfiles/rails52.gemfile.lock
@@ -156,6 +156,3 @@ DEPENDENCIES
   rails (~> 5.2.0)
   rake (~> 13.3)
   rspec
-
-BUNDLED WITH
-   2.6.3

--- a/gemfiles/rails60.gemfile.lock
+++ b/gemfiles/rails60.gemfile.lock
@@ -172,6 +172,3 @@ DEPENDENCIES
   rails (~> 6.0.0)
   rake (~> 13.3)
   rspec
-
-BUNDLED WITH
-   2.6.3

--- a/gemfiles/rails61.gemfile.lock
+++ b/gemfiles/rails61.gemfile.lock
@@ -175,6 +175,3 @@ DEPENDENCIES
   rails (~> 6.1.0)
   rake (~> 13.3)
   rspec
-
-BUNDLED WITH
-   2.6.3

--- a/gemfiles/rails70.gemfile.lock
+++ b/gemfiles/rails70.gemfile.lock
@@ -172,6 +172,3 @@ DEPENDENCIES
   rails (~> 7.0.0)
   rake (~> 13.3)
   rspec
-
-BUNDLED WITH
-   2.6.3

--- a/gemfiles/rails71.gemfile.lock
+++ b/gemfiles/rails71.gemfile.lock
@@ -217,6 +217,3 @@ DEPENDENCIES
   rails (~> 7.1.0)
   rake (~> 13.3)
   rspec
-
-BUNDLED WITH
-   2.6.3

--- a/gemfiles/rails72.gemfile.lock
+++ b/gemfiles/rails72.gemfile.lock
@@ -211,6 +211,3 @@ DEPENDENCIES
   rails (~> 7.2.0)
   rake (~> 13.3)
   rspec
-
-BUNDLED WITH
-   2.6.3

--- a/gemfiles/rails80.gemfile.lock
+++ b/gemfiles/rails80.gemfile.lock
@@ -208,6 +208,3 @@ DEPENDENCIES
   rails (~> 8.0.0)
   rake (~> 13.3)
   rspec
-
-BUNDLED WITH
-   2.6.3


### PR DESCRIPTION
- [x] Needs new version of setup-ruby action with JRuby 10.0.1.0 enumerated

I removed the locked bundler versions as the `bundler-maven-plugin` seems to have issues switching bundler versions dynamically when run within GitHub Actions in some cases, which only seems to happen when the default jruby bundler version is different to that locked in the lockfile. Errors are like the below (changed as default bundler version packaged with jruby 10.0.1.0 [moved to 2.6.9](https://github.com/jruby/jruby/pull/8865/files))

Since I can't find a way to "fix" this, easier to just remove the locked versions and use the versions implied by the JRuby version under test.

```
Errno::ENOENT: No such file or directory - /usr/lib/jvm/temurin-21-jdk-amd64/bin/java -cp /home/runner/.m2/repository/org/jruby/jruby-complete/10.0.1.0/jruby-complete-10.0.1.0.jar:/home/runner/work/jruby-rack/jruby-rack/target/test-classes:/home/runner/work/jruby-rack/jruby-rack/target/classes:/home/runner/.m2/repository/org/jruby/jruby-core/10.0.1.0/jruby-core-10.0.1.0.jar:/home/runner/.m2/repository/javax/servlet/javax.servlet-api/3.0.1/javax.servlet-api-3.0.1.jar:/home/runner/.m2/repository/jakarta/servlet/jsp/jakarta.servlet.jsp-api/2.3.6/jakarta.servlet.jsp-api-2.3.6.jar:/home/runner/.m2/repository/commons-logging/commons-logging/1.3.5/commons-logging-1.3.5.jar:/home/runner/.m2/repository/org/slf4j/slf4j-api/2.0.17/slf4j-api-2.0.17.jar:/home/runner/.m2/repository/org/slf4j/slf4j-simple/2.0.17/slf4j-simple-2.0.17.jar:/home/runner/.m2/repository/org/springframework/spring-web/4.3.30.RELEASE/spring-web-4.3.30.RELEASE.jar:/home/runner/.m2/repository/org/springframework/spring-aop/4.3.30.RELEASE/spring-aop-4.3.30.RELEASE.jar:/home/runner/.m2/repository/org/springframework/spring-beans/4.3.30.RELEASE/spring-beans-4.3.30.RELEASE.jar:/home/runner/.m2/repository/org/springframework/spring-context/4.3.30.RELEASE/spring-context-4.3.30.RELEASE.jar:/home/runner/.m2/repository/org/springframework/spring-expression/4.3.30.RELEASE/spring-expression-4.3.30.RELEASE.jar:/home/runner/.m2/repository/org/springframework/spring-core/4.3.30.RELEASE/spring-core-4.3.30.RELEASE.jar:/home/runner/.m2/repository/org/springframework/spring-test/4.3.30.RELEASE/spring-test-4.3.30.RELEASE.jar:/home/runner/.m2/repository/jakarta/el/jakarta.el-api/3.0.3/jakarta.el-api-3.0.3.jar:/home/runner/.m2/repository/org/jruby/jruby-complete/10.0.1.0/jruby-complete-10.0.1.0.jar org.jruby.Main
  org/jruby/RubyKernel.java:1957:in '_exec_internal'
          <internal:uri:classloader:/jruby/kernel/kernel.rb>:3:in 'exec'
          uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/self_manager.rb:93:in 'block in restart_with'
          uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler.rb:393:in 'block in with_original_env'
          uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler.rb:696:in 'with_env'
          uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler.rb:393:in 'with_original_env'
          uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/self_manager.rb:92:in 'restart_with'
          uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/self_manager.rb:62:in 'install_and_restart_with'
          uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/self_manager.rb:28:in 'install_locked_bundler_and_restart_with_it_if_needed'
          uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/cli/install.rb:18:in 'run'
          uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/cli.rb:247:in 'block in install'
          uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/settings.rb:159:in 'temporary'
          uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/cli.rb:246:in 'install'
          uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/vendor/thor/lib/thor/command.rb:28:in 'run'
          uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/vendor/thor/lib/thor/invocation.rb:127:in 'invoke_command'
          uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/vendor/thor/lib/thor.rb:538:in 'dispatch'
          uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/cli.rb:35:in 'dispatch'
          uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/vendor/thor/lib/thor/base.rb:584:in 'start'
          uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/cli.rb:29:in 'start'
          uri:classloader:/META-INF/jruby.home/lib/ruby/gems/shared/gems/bundler-2.6.9/exe/bundle:28:in 'block in <main>'
          uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/friendly_errors.rb:117:in 'with_friendly_errors'
          uri:classloader:/META-INF/jruby.home/lib/ruby/gems/shared/gems/bundler-2.6.9/exe/bundle:20:in '<main>'
          org/jruby/RubyKernel.java:1212:in 'load'
          uri:classloader:/META-INF/jruby.home/bin/bundle:25:in '<main>'
```