### PR TITLE
LoggerSilence support within Rails

### DIFF
--- a/src/main/ruby/jruby/rack/rails/rails_logger.rb
+++ b/src/main/ruby/jruby/rack/rails/rails_logger.rb
@@ -1,0 +1,7 @@
+require 'active_support/logger_silence' unless defined?(ActiveSupport::LoggerSilence)
+
+module JRuby::Rack
+  class RailsLogger < JRuby::Rack::Logger
+    include ActiveSupport::LoggerSilence
+  end
+end

--- a/src/main/ruby/jruby/rack/rails/railtie.rb
+++ b/src/main/ruby/jruby/rack/rails/railtie.rb
@@ -32,16 +32,21 @@ module JRuby::Rack
 
     initializer 'set_servlet_logger', :before => :initialize_logger do |app|
       app.config.logger ||= begin
-        logger = JRuby::Rack.logger
+        require 'jruby/rack/rails/rails_logger'
+        logger = JRuby::Rack::RailsLogger.new(JRuby::Rack.context)
         config = app.config
         log_level = config.log_level
+        # NOTE: not much sense to set the level to a default (e.g. :info), esp. with Java logging backends
+        # one could also argue we should disable silencing
+        #
+        #   JRuby::Rack::RailsLogger.silencer = false
+        #
+        # although that would potentially only make sense when Java (jruby.rack.logging) backend is used.
         logger.level = logger.class.const_get(log_level.to_s.upcase) if log_level
         log_formatter = config.log_formatter if config.respond_to?(:log_formatter)
         logger.formatter = log_formatter if log_formatter && logger.respond_to?(:formatter=)
         require 'active_support/tagged_logging' unless defined?(ActiveSupport::TaggedLogging)
-        logger = ActiveSupport::TaggedLogging.new(logger) # returns a logger.clone
-        logger.singleton_class.send(:include, ActiveSupport::LoggerSilence) if defined?(ActiveSupport::LoggerSilence)
-        logger
+        ActiveSupport::TaggedLogging.new(logger) # returns a logger.clone
       end
     end
 

--- a/src/main/ruby/jruby/rack/rails/railtie.rb
+++ b/src/main/ruby/jruby/rack/rails/railtie.rb
@@ -34,8 +34,8 @@ module JRuby::Rack
       app.config.logger ||= begin
         logger = JRuby::Rack.logger
         config = app.config
-        log_level = config.log_level || :info
-        logger.level = logger.class.const_get(log_level.to_s.upcase)
+        log_level = config.log_level
+        logger.level = logger.class.const_get(log_level.to_s.upcase) if log_level
         log_formatter = config.log_formatter if config.respond_to?(:log_formatter)
         logger.formatter = log_formatter if log_formatter && logger.respond_to?(:formatter=)
         require 'active_support/tagged_logging' unless defined?(ActiveSupport::TaggedLogging)


### PR DESCRIPTION
second attempt at Rails' `LoggerSilence` (based on what was initially suggested https://github.com/jruby/jruby-rack/pull/270), an alternative for https://github.com/jruby/jruby-rack/pull/303

the previous approach made more sense but we can not really `singleton_class.send(:include, ActiveSupport::LoggerSilence)`, in actual Rails...

```
(TypeError) module attributes should be defined directly on class, not singleton
	at RUBY.mattr_reader(/opt/local/rvm/gems/jruby-9.4.13.0@temp/gems/activesupport-7.2.2.1/lib/active_support/core_ext/module/attribute_accessors.rb:56)
	at RUBY.mattr_accessor(/opt/local/rvm/gems/jruby-9.4.13.0@temp/gems/activesupport-7.2.2.1/lib/active_support/core_ext/module/attribute_accessors.rb:210)
	at RUBY.LoggerSilence(/opt/local/rvm/gems/jruby-9.4.13.0@temp/gems/activesupport-7.2.2.1/lib/active_support/logger_silence.rb:12)
	at org.jruby.RubyModule.module_eval(org/jruby/RubyModule.java:3723)
	at org.jruby.RubyModule.module_eval(org/jruby/RubyModule.java:3754)
	at RUBY.append_features(/opt/local/rvm/gems/jruby-9.4.13.0@temp/gems/activesupport-7.2.2.1/lib/active_support/concern.rb:138)
	at org.jruby.RubyModule.include(org/jruby/RubyModule.java:3384)
	at RUBY.Railtie(uri:classloader:/jruby/rack/rails/railtie.rb:43)
````