### PR TITLE
1.2.x: [fix] ensure compatibility with JRuby 10.1

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        jruby_version: [ '9.3.15.0', '9.4.14.0', '10.0.5.0' ]
+        jruby_version: [ '9.3.15.0', '9.4.14.0', '10.0.5.0', '10.1.0.0' ]
         java_version: [ '8', '11', '17', '21', '25' ]
         rack_version: [ '~> 2.2.0' ]
         exclude:
@@ -28,6 +28,12 @@ jobs:
           - jruby_version: '10.0.5.0'
             java_version: '11' # JRuby 10 requires Java 21
           - jruby_version: '10.0.5.0'
+            java_version: '17' # JRuby 10 requires Java 21
+          - jruby_version: '10.1.0.0'
+            java_version: '8'  # JRuby 10 requires Java 21
+          - jruby_version: '10.1.0.0'
+            java_version: '11' # JRuby 10 requires Java 21
+          - jruby_version: '10.1.0.0'
             java_version: '17' # JRuby 10 requires Java 21
       fail-fast: false
 
@@ -68,7 +74,7 @@ jobs:
           'rails72_rack22',
           'rails80_rack22',
         ]
-        jruby_version: [ '9.3.15.0', '9.4.14.0', '10.0.5.0' ]
+        jruby_version: [ '9.3.15.0', '9.4.14.0', '10.0.5.0', '10.1.0.0' ]
         java_version: [ '8', '11', '17', '21', '25' ]
         exclude:
           - jruby_version: '10.0.5.0'
@@ -76,6 +82,12 @@ jobs:
           - jruby_version: '10.0.5.0'
             java_version: '11' # JRuby 10 requires Java 21
           - jruby_version: '10.0.5.0'
+            java_version: '17' # JRuby 10 requires Java 21
+          - jruby_version: '10.1.0.0'
+            java_version: '8'  # JRuby 10 requires Java 21
+          - jruby_version: '10.1.0.0'
+            java_version: '11' # JRuby 10 requires Java 21
+          - jruby_version: '10.1.0.0'
             java_version: '17' # JRuby 10 requires Java 21
           - appraisal: 'rails70_rack22' # Requires Ruby 2.7 compatibility, which JRuby 9.3 does not support
             jruby_version: '9.3.15.0'

--- a/Appraisals
+++ b/Appraisals
@@ -2,10 +2,10 @@ version_spec = ->(prefix, desc) { "~> #{desc.split(prefix).last.insert(1, ".")}.
 
 # rails#{MAJOR}#{MINOR} => config_obj
 {
-  "rails50" => {racks: %w[rack22], ext_gems: %w[mutex_m bigdecimal base64]},
-  "rails52" => {racks: %w[rack22], ext_gems: %w[mutex_m bigdecimal]},
-  "rails60" => {racks: %w[rack22], ext_gems: %w[mutex_m bigdecimal]},
-  "rails61" => {racks: %w[rack22], ext_gems: %w[mutex_m bigdecimal]},
+  "rails50" => {racks: %w[rack22], ext_gems: %w[mutex_m bigdecimal benchmark base64]},
+  "rails52" => {racks: %w[rack22], ext_gems: %w[mutex_m bigdecimal benchmark]},
+  "rails60" => {racks: %w[rack22], ext_gems: %w[mutex_m bigdecimal benchmark]},
+  "rails61" => {racks: %w[rack22], ext_gems: %w[mutex_m bigdecimal benchmark]},
   "rails70" => {racks: %w[rack22]},
   "rails71" => {racks: %w[rack22]},
   "rails72" => {racks: %w[rack22]},

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.2.7 (UNRELEASED)
 
-- Fix compatibility with JRuby 10.0 and Rails 8.0 (#419)
+- Ensure compatibility with JRuby 10.0 and 10.1 (#419)
+- Ensure compatibility with Rails 8.0 (#419)
 - Fix ability to include and forward to JSPs under Rails (#370)
 - Update (bundled) rack to 2.2.23 (#417)
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,5 +12,8 @@ group :development do
   gem 'appraisal', :require => nil
 end
 
-gem 'rake', '~> 13.4', :group => :test, :require => nil
-gem 'rspec', :group => :test
+group :test do
+  gem 'rake', '~> 13.4', :require => nil
+  gem 'rspec'
+  gem 'logger'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ GEM
       rake
       thor (>= 0.14.0)
     diff-lcs (1.6.2)
+    logger (1.7.0)
     rack (2.2.23)
     rake (13.4.2)
     rspec (3.13.2)
@@ -34,6 +35,20 @@ PLATFORMS
 
 DEPENDENCIES
   appraisal
+  logger
   rack (~> 2.2.23)
   rake (~> 13.4)
   rspec
+
+CHECKSUMS
+  appraisal (2.5.0) sha256=36989221be127913b0dba8d114da2001e6b2dceea7bd4951200eaba764eed3ce
+  diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  rack (2.2.23) sha256=a8fe9d7e07064770b8ec123663fded8a59ef7e2b6db5cda7173d45a5718ab69c
+  rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587
+  rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
+  rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
+  rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
+  rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
+  thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For more information on Rack, visit http://rack.github.io/.
 
 | JRuby-Rack Series                                              | Status        | Rack      | JRuby      | Java | Rails     | Target Servlet API | Notes                                                          |
 |----------------------------------------------------------------|---------------|-----------|------------|------|-----------|--------------------|----------------------------------------------------------------|
-| [**1.2**](https://github.com/jruby/jruby-rack/tree/1.2-stable) | Maintained    | 2.2       | 9.3 → 10.0 | 8+   | 5.0 → 8.0 | 3.0 (Java EE 6)    | ✅ _Unofficial_: Servlet 3.1 → 4.0 also OK with most containers |
+| [**1.2**](https://github.com/jruby/jruby-rack/tree/1.2-stable) | Maintained    | 2.2       | 9.3 → 10.1 | 8+   | 5.0 → 8.0 | 3.0 (Java EE 6)    | ✅ _Unofficial_: Servlet 3.1 → 4.0 also OK with most containers |
 | [**1.1**](https://github.com/jruby/jruby-rack/tree/1.1-stable) | EOL @ 2024-05 | 1.x → 2.2 | 1.6 → 9.4  | 6+   | 2.1 → 5.2 | 2.5 (Java EE 5)    | ✅ _Unofficial_: Servlet 3.0 → 4.0 also OK with most containers |
 | [**1.0**](https://github.com/jruby/jruby-rack/tree/1.0.10)     | EOL @ 2011-11 | 0.9 → 1.x | 1.1 → 1.9  | 5+   | 2.1 → 3.x | 2.5 (Java EE 5)    |                                                                |
 

--- a/gemfiles/rails50_rack22.gemfile
+++ b/gemfiles/rails50_rack22.gemfile
@@ -2,17 +2,21 @@
 
 source "https://rubygems.org"
 
-gem "rake", "~> 13.4", group: :test, require: nil
-gem "rspec", group: :test
-
 group :default do
   gem "rack", "~> 2.2.0"
   gem "rails", "~> 5.0.0"
   gem "mutex_m"
   gem "bigdecimal"
+  gem "benchmark"
   gem "base64"
 end
 
 group :development do
   gem "appraisal", require: nil
+end
+
+group :test do
+  gem "rake", "~> 13.4", require: nil
+  gem "rspec"
+  gem "logger"
 end

--- a/gemfiles/rails52_rack22.gemfile
+++ b/gemfiles/rails52_rack22.gemfile
@@ -2,16 +2,20 @@
 
 source "https://rubygems.org"
 
-gem "rake", "~> 13.4", group: :test, require: nil
-gem "rspec", group: :test
-
 group :default do
   gem "rack", "~> 2.2.0"
   gem "rails", "~> 5.2.0"
   gem "mutex_m"
   gem "bigdecimal"
+  gem "benchmark"
 end
 
 group :development do
   gem "appraisal", require: nil
+end
+
+group :test do
+  gem "rake", "~> 13.4", require: nil
+  gem "rspec"
+  gem "logger"
 end

--- a/gemfiles/rails60_rack22.gemfile
+++ b/gemfiles/rails60_rack22.gemfile
@@ -2,16 +2,20 @@
 
 source "https://rubygems.org"
 
-gem "rake", "~> 13.4", group: :test, require: nil
-gem "rspec", group: :test
-
 group :default do
   gem "rack", "~> 2.2.0"
   gem "rails", "~> 6.0.0"
   gem "mutex_m"
   gem "bigdecimal"
+  gem "benchmark"
 end
 
 group :development do
   gem "appraisal", require: nil
+end
+
+group :test do
+  gem "rake", "~> 13.4", require: nil
+  gem "rspec"
+  gem "logger"
 end

--- a/gemfiles/rails61_rack22.gemfile
+++ b/gemfiles/rails61_rack22.gemfile
@@ -2,16 +2,20 @@
 
 source "https://rubygems.org"
 
-gem "rake", "~> 13.4", group: :test, require: nil
-gem "rspec", group: :test
-
 group :default do
   gem "rack", "~> 2.2.0"
   gem "rails", "~> 6.1.0"
   gem "mutex_m"
   gem "bigdecimal"
+  gem "benchmark"
 end
 
 group :development do
   gem "appraisal", require: nil
+end
+
+group :test do
+  gem "rake", "~> 13.4", require: nil
+  gem "rspec"
+  gem "logger"
 end

--- a/gemfiles/rails70_rack22.gemfile
+++ b/gemfiles/rails70_rack22.gemfile
@@ -2,9 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rake", "~> 13.4", group: :test, require: nil
-gem "rspec", group: :test
-
 group :default do
   gem "rack", "~> 2.2.0"
   gem "rails", "~> 7.0.0"
@@ -12,4 +9,10 @@ end
 
 group :development do
   gem "appraisal", require: nil
+end
+
+group :test do
+  gem "rake", "~> 13.4", require: nil
+  gem "rspec"
+  gem "logger"
 end

--- a/gemfiles/rails71_rack22.gemfile
+++ b/gemfiles/rails71_rack22.gemfile
@@ -2,9 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rake", "~> 13.4", group: :test, require: nil
-gem "rspec", group: :test
-
 group :default do
   gem "rack", "~> 2.2.0"
   gem "rails", "~> 7.1.0"
@@ -12,4 +9,10 @@ end
 
 group :development do
   gem "appraisal", require: nil
+end
+
+group :test do
+  gem "rake", "~> 13.4", require: nil
+  gem "rspec"
+  gem "logger"
 end

--- a/gemfiles/rails72_rack22.gemfile
+++ b/gemfiles/rails72_rack22.gemfile
@@ -2,9 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rake", "~> 13.4", group: :test, require: nil
-gem "rspec", group: :test
-
 group :default do
   gem "rack", "~> 2.2.0"
   gem "rails", "~> 7.2.0"
@@ -12,4 +9,10 @@ end
 
 group :development do
   gem "appraisal", require: nil
+end
+
+group :test do
+  gem "rake", "~> 13.4", require: nil
+  gem "rspec"
+  gem "logger"
 end

--- a/gemfiles/rails80_rack22.gemfile
+++ b/gemfiles/rails80_rack22.gemfile
@@ -2,9 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rake", "~> 13.4", group: :test, require: nil
-gem "rspec", group: :test
-
 group :default do
   gem "rack", "~> 2.2.0"
   gem "rails", "~> 8.0.0"
@@ -12,4 +9,10 @@ end
 
 group :development do
   gem "appraisal", require: nil
+end
+
+group :test do
+  gem "rake", "~> 13.4", require: nil
+  gem "rspec"
+  gem "logger"
 end

--- a/src/main/java/org/jruby/rack/DefaultErrorApplication.java
+++ b/src/main/java/org/jruby/rack/DefaultErrorApplication.java
@@ -75,8 +75,7 @@ public class DefaultErrorApplication extends DefaultRackApplication
     private class Response implements RackResponse {
 
         private int status = 500;
-        @SuppressWarnings("rawtypes")
-        private Map headers = Collections.EMPTY_MAP;
+        private Map<String, ?> headers = Collections.emptyMap();
         private String body;
 
         protected final RackEnvironment env;
@@ -99,9 +98,9 @@ public class DefaultErrorApplication extends DefaultRackApplication
             return headers;
         }
 
-        @SuppressWarnings("unused")
+        @SuppressWarnings({"unused", "unchecked"})
         public void setHeaders(@SuppressWarnings("rawtypes") Map headers) {
-            this.headers = headers == null ? Collections.EMPTY_MAP : headers;
+            this.headers = headers == null ? Collections.emptyMap() : headers;
         }
 
         @Override

--- a/src/main/java/org/jruby/rack/DefaultRackApplication.java
+++ b/src/main/java/org/jruby/rack/DefaultRackApplication.java
@@ -50,13 +50,8 @@ public class DefaultRackApplication implements RackApplication {
         final IRubyObject app = getApplication();
         final Ruby runtime = getRuntime();
         final IRubyObject servlet_env = JavaEmbedUtils.javaToRuby(runtime, env);
-        //try { // app.call(env) :
         final IRubyObject response = app.callMethod(runtime.getCurrentContext(), "call", servlet_env);
-        return (RackResponse) response.toJava(RackResponse.class);
-        //}
-        //catch (RuntimeException e) {
-        //    throw ExceptionUtils.wrapException(runtime, e);
-        //}
+        return response.toJava(RackResponse.class);
     }
 
     @Override

--- a/src/main/java/org/jruby/rack/DefaultRackApplicationFactory.java
+++ b/src/main/java/org/jruby/rack/DefaultRackApplicationFactory.java
@@ -202,7 +202,7 @@ public class DefaultRackApplicationFactory implements RackApplicationFactory {
 
     public RackApplication newErrorApplication() {
         Boolean error = rackContext.getConfig().getBooleanProperty("jruby.rack.error");
-        if ( error != null && ! error.booleanValue() ) { // jruby.rack.error = false
+        if ( error != null && !error) { // jruby.rack.error = false
             return new DefaultErrorApplication(rackContext);
         }
         try {
@@ -585,7 +585,7 @@ public class DefaultRackApplicationFactory implements RackApplicationFactory {
         if (iniSize == null) iniSize = RewindableInputStream.INI_BUFFER_SIZE;
         Integer maxSize = config.getMaximumMemoryBufferSize();
         if (maxSize == null) maxSize = RewindableInputStream.MAX_BUFFER_SIZE;
-        if (iniSize.intValue() > maxSize.intValue()) iniSize = maxSize;
+        if (iniSize > maxSize) iniSize = maxSize;
 
         RewindableInputStream.setDefaultInitialBufferSize(iniSize);
         RewindableInputStream.setDefaultMaximumBufferSize(maxSize);

--- a/src/main/java/org/jruby/rack/DefaultRackConfig.java
+++ b/src/main/java/org/jruby/rack/DefaultRackConfig.java
@@ -130,7 +130,7 @@ public class DefaultRackConfig implements RackConfig {
                 }
             }
         }
-        return serial.booleanValue();
+        return serial;
     }
 
     @Override
@@ -282,8 +282,7 @@ public class DefaultRackConfig implements RackConfig {
     static boolean isIgnoreRUBYOPT(RackConfig config) {
         // RUBYOPT ignored if jruby.runtime.env.rubyopt = false
         Boolean rubyopt = config.getBooleanProperty("jruby.runtime.env.rubyopt");
-        if ( rubyopt == null ) return ! config.isIgnoreEnvironment();
-        return rubyopt != null && ! rubyopt.booleanValue();
+        return rubyopt == null ? !config.isIgnoreEnvironment() : !rubyopt;
     }
 
     @Override
@@ -297,14 +296,11 @@ public class DefaultRackConfig implements RackConfig {
 
     static boolean isThrowInitException(RackConfig config) {
         Boolean error = config.getBooleanProperty("jruby.rack.error");
-        if ( error != null && ! error.booleanValue() ) {
+        if ( error != null && !error) {
             return true; // jruby.rack.error = false
         }
         error = config.getBooleanProperty("jruby.rack.exception");
-        if ( error != null && ! error.booleanValue() ) {
-            return true; // jruby.rack.exception = false
-        }
-        return false;
+        return error != null && !error; // jruby.rack.exception = false
     }
 
     @Override
@@ -350,7 +346,7 @@ public class DefaultRackConfig implements RackConfig {
         if (value == null) return null;
         try {
             int i = Integer.parseInt(value);
-            if (i > 0) return Integer.valueOf(i);
+            if (i > 0) return i;
         } catch (Exception e) { /* ignored */ }
         return null;
     }
@@ -382,12 +378,12 @@ public class DefaultRackConfig implements RackConfig {
             }
             if ( number == ((int) number) )
             if ( number > Integer.MAX_VALUE ) {
-                return Long.valueOf((long) number);
+                return (long) number;
             }
             else {
-                return Integer.valueOf((int) number);
+                return (int) number;
             }
-            return Float.valueOf(number);
+            return number;
         }
         catch (Exception e) { /* ignored */ }
         return defaultValue;
@@ -409,7 +405,7 @@ public class DefaultRackConfig implements RackConfig {
                 for ( final String entry : entries ) {
                     String[] pair = entry.split("=", 2);
                     if ( pair.length == 1 ) { // no = separator
-                        if ( entry.trim().length() == 0 ) continue;
+                        if ( entry.trim().isEmpty() ) continue;
                         if ( lastKey == null ) continue; // missing key
                         map.put( lastKey, lastVal = lastVal + ',' + entry );
                     }

--- a/src/main/java/org/jruby/rack/DefaultRackDispatcher.java
+++ b/src/main/java/org/jruby/rack/DefaultRackDispatcher.java
@@ -55,7 +55,7 @@ public class DefaultRackDispatcher extends AbstractRackDispatcher {
             // TODO seems redundant maybe we should let the container decide ?!
             context.log(RackLogger.ERROR, "error app failed to handle exception: " + e, re);
             Integer errorCode = getErrorApplicationFailureStatusCode();
-            if ( errorCode != null && errorCode.intValue() > 0 ) {
+            if ( errorCode != null && errorCode > 0 ) {
                 response.sendError(errorCode);
             }
             else {

--- a/src/main/java/org/jruby/rack/PoolingRackApplicationFactory.java
+++ b/src/main/java/org/jruby/rack/PoolingRackApplicationFactory.java
@@ -390,14 +390,14 @@ public class PoolingRackApplicationFactory extends RackApplicationFactoryDecorat
         if ( waitNum != null ) {
             int wait = waitNum.intValue();
             if (maximumSize != null && wait > maximumSize) {
-                wait = maximumSize.intValue();
+                wait = maximumSize;
             }
             return wait;
         }
         // otherwise we assume it to be a boolean true/false flag :
         Boolean waitFlag = getConfig().getBooleanProperty("jruby.runtime.init.wait");
         if ( waitFlag == null ) waitFlag = Boolean.TRUE;
-        return waitFlag ? ( initialSize == null ? 1 : initialSize.intValue() ) : 0;
+        return waitFlag ? ( initialSize == null ? 1 : initialSize) : 0;
         // NOTE: this slightly changes the behavior in 1.1.8, in previous
         // versions the initialization only waited for 1 application instance
         // to be available in the pool - here by default we wait till initial
@@ -406,7 +406,7 @@ public class PoolingRackApplicationFactory extends RackApplicationFactoryDecorat
 
     @Override
     public Collection<RackApplication> getManagedApplications() {
-        int initSize = initialSize != null ? initialSize.intValue() : -1;
+        int initSize = initialSize != null ? initialSize : -1;
         synchronized (applicationPool) {
             if ( applicationPool.isEmpty() ) {
                 if ( initSize > 0 ) return null; // ~ init error

--- a/src/main/java/org/jruby/rack/UnmappedRackFilter.java
+++ b/src/main/java/org/jruby/rack/UnmappedRackFilter.java
@@ -8,10 +8,8 @@ package org.jruby.rack;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Collectors;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
@@ -46,7 +44,7 @@ public class UnmappedRackFilter extends AbstractFilter {
 
     private static final Collection<Integer> RESPONSE_NOT_HANDLED_STATUSES;
     static {
-        final HashSet<Integer> statuses = new HashSet<>(8, 1);
+        final Set<Integer> statuses = new HashSet<>(8, 1);
         statuses.add( 404 );
         // 403 due containers not supporting PUT/DELETE correctly (Tomcat 6)
         statuses.add( 403 );
@@ -61,7 +59,7 @@ public class UnmappedRackFilter extends AbstractFilter {
     private RackContext context;
     private RackDispatcher dispatcher;
 
-    public UnmappedRackFilter() { /** constructor used by container */ }
+    public UnmappedRackFilter() { /* constructor used by container */ }
 
     /**
      * Dependency-injected constructor for testing
@@ -89,14 +87,11 @@ public class UnmappedRackFilter extends AbstractFilter {
         // ResponseCapture.notHandledStatuses e.g. "403,404,500"
         value = config.getInitParameter("responseNotHandledStatuses");
         if ( value != null ) {
-            final Set<Integer> statuses = new HashSet<>();
-            for ( String status : value.split(",") ) {
-                status = status.trim();
-                if ( status.length() > 0 ) {
-                    statuses.add( Integer.parseInt(status) );
-                }
-            }
-            responseNotHandledStatuses = statuses;
+            responseNotHandledStatuses = Arrays.stream(value.split(","))
+                    .map(String::trim)
+                    .filter(status -> !status.isEmpty())
+                    .map(Integer::parseInt)
+                    .collect(Collectors.toSet());
         }
         // ResponseCapture.handledByDefault true/false (true by default)
         value = config.getInitParameter("responseHandledByDefault");
@@ -180,7 +175,7 @@ public class UnmappedRackFilter extends AbstractFilter {
     }
 
     public void setResetUnhandledResponse(boolean reset) {
-        this.resetUnhandledResponse = Boolean.valueOf(reset);
+        this.resetUnhandledResponse = reset;
     }
 
     public boolean isResetUnhandledResponseBuffer() {
@@ -204,10 +199,9 @@ public class UnmappedRackFilter extends AbstractFilter {
         return this.responseNotHandledStatuses;
     }
 
-    @SuppressWarnings("unchecked")
     public void setDefaultNotHandledStatuses(final Collection<Integer> responseNotHandledStatuses) {
         this.responseNotHandledStatuses =
-            responseNotHandledStatuses == null ? Collections.EMPTY_SET : responseNotHandledStatuses;
+            responseNotHandledStatuses == null ? Collections.emptySet() : responseNotHandledStatuses;
     }
 
     public boolean isResponseHandledByDefault() {

--- a/src/main/java/org/jruby/rack/ext/Response.java
+++ b/src/main/java/org/jruby/rack/ext/Response.java
@@ -50,12 +50,12 @@ import org.jruby.javasupport.JavaUtil;
 import org.jruby.rack.RackException;
 import org.jruby.rack.RackResponse;
 import org.jruby.rack.RackResponseEnvironment;
-import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.BlockBody;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.JavaInternalBlockBody;
 import org.jruby.runtime.ObjectAllocator;
+import org.jruby.runtime.Signature;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -93,7 +93,7 @@ public class Response extends RubyObject implements RackResponse {
     @JRubyMethod(name = "swallow_client_abort=", meta = true, required = 1)
     public static IRubyObject set_swallow_client_abort(final IRubyObject self, final IRubyObject value) {
         if ( value instanceof RubyBoolean ) {
-            swallowClientAbort = ((RubyBoolean) value).isTrue();
+            swallowClientAbort = value.isTrue();
         }
         else {
             swallowClientAbort = ! value.isNil();
@@ -124,7 +124,7 @@ public class Response extends RubyObject implements RackResponse {
     @JRubyMethod(name = "dechunk=", meta = true, required = 1)
     public static IRubyObject set_dechunk(final IRubyObject self, final IRubyObject value) {
         if ( value instanceof RubyBoolean ) {
-            dechunk = ((RubyBoolean) value).isTrue();
+            dechunk = value.isTrue();
         }
         else {
             dechunk = ! value.isNil();
@@ -138,7 +138,7 @@ public class Response extends RubyObject implements RackResponse {
      * Returns the channel chunk size to be used e.g. when a (send) file
      * response is detected. By setting this value to nil you force an "explicit"
      * byte buffer to be used when copying between channels.
-     *
+     * <p>
      * Note: High values won't hurt when sending small files since most Java
      * (file) channel implementations handle this gracefully. However if you're
      * on Windows it is  recommended to not set this higher than the "magic"
@@ -169,7 +169,7 @@ public class Response extends RubyObject implements RackResponse {
         }
         else {
             final long val = value.convertToInteger("to_i").getLongValue();
-            channelChunkSize = Integer.valueOf((int) val);
+            channelChunkSize = (int) val;
         }
         return value;
     }
@@ -204,7 +204,7 @@ public class Response extends RubyObject implements RackResponse {
         }
         else {
             final long val = value.convertToInteger("to_i").getLongValue();
-            channelBufferSize = Integer.valueOf((int) val);
+            channelBufferSize = (int) val;
         }
         return value;
     }
@@ -228,7 +228,7 @@ public class Response extends RubyObject implements RackResponse {
     @JRubyMethod(required = 1)
     public IRubyObject initialize(final ThreadContext context, final IRubyObject arg) {
         if ( arg instanceof RubyArray ) {
-            final RubyArray arr = (RubyArray) arg;
+            final RubyArray<?> arr = (RubyArray<?>) arg;
             if ( arr.size() < 3 ) {
                 throw context.runtime.newArgumentError("expected 3 array elements (rack-respose)");
             }
@@ -297,10 +297,10 @@ public class Response extends RubyObject implements RackResponse {
         try {
             final StringBuilder bodyParts = new StringBuilder();
             invoke(context, this.body, "each",
-                new JavaInternalBlockBody(context.runtime, Arity.ONE_REQUIRED) {
+                new JavaInternalBlockBody(context.runtime, Signature.ONE_REQUIRED) {
                     @Override
                     public IRubyObject yield(ThreadContext context, IRubyObject[] args) {
-                        return yield(context, args[0]);
+                        return this.yield(context, args[0]);
                     }
 
                     @Override
@@ -347,7 +347,7 @@ public class Response extends RubyObject implements RackResponse {
 
     @JRubyMethod(name = "write_status")
     public IRubyObject write_status(final ThreadContext context, final IRubyObject response) {
-        writeStatus( (RackResponseEnvironment) response.toJava(RackResponseEnvironment.class) );
+        writeStatus(response.toJava(RackResponseEnvironment.class));
         return context.nil;
     }
 
@@ -358,7 +358,7 @@ public class Response extends RubyObject implements RackResponse {
     @JRubyMethod(name = "write_headers")
     public IRubyObject write_headers(final ThreadContext context, final IRubyObject response)
         throws IOException {
-        writeHeaders( (RackResponseEnvironment) response.toJava(RackResponseEnvironment.class) );
+        writeHeaders(response.toJava(RackResponseEnvironment.class));
         return context.nil;
     }
 
@@ -394,10 +394,10 @@ public class Response extends RubyObject implements RackResponse {
                     final RubyString newLine = RubyString.newString(context.runtime, NEW_LINE);
                     // value.each_line { |val| response.addHeader(key.to_s, val.chomp("\n")) }
                     invoke(context, val, each_line ? "each_line" : "each",
-                        new JavaInternalBlockBody(context.runtime, Arity.ONE_REQUIRED) {
+                        new JavaInternalBlockBody(context.runtime, Signature.ONE_REQUIRED) {
                             @Override
                             public IRubyObject yield(ThreadContext context, IRubyObject[] args) {
-                                return yield(context, args[0]);
+                                return this.yield(context, args[0]);
                             }
 
                             @Override
@@ -430,7 +430,7 @@ public class Response extends RubyObject implements RackResponse {
     @JRubyMethod(name = "write_body")
     public IRubyObject write_body(final ThreadContext context, final IRubyObject response)
         throws IOException {
-        writeBody( (RackResponseEnvironment) response.toJava(RackResponseEnvironment.class) );
+        writeBody(response.toJava(RackResponseEnvironment.class));
         return context.nil;
     }
 
@@ -463,7 +463,7 @@ public class Response extends RubyObject implements RackResponse {
                 else {
                     final ThreadContext context = currentContext();
                     final IRubyObject channel = body.callMethod(context, "to_channel");
-                    bodyChannel = (Channel) channel.toJava(Channel.class);
+                    bodyChannel = channel.toJava(Channel.class);
                 }
                 if ( bodyChannel instanceof FileChannel ) {
                     transferChannel( (FileChannel) bodyChannel, response.getOutputStream() );
@@ -486,10 +486,10 @@ public class Response extends RubyObject implements RackResponse {
                 final String method = body.respondsTo("each_line") ? "each_line" : "each";
                 try {
                     invoke(context, body, method,
-                        new JavaInternalBlockBody(context.runtime, Arity.ONE_REQUIRED) {
+                        new JavaInternalBlockBody(context.runtime, Signature.ONE_REQUIRED) {
                         @Override
                         public IRubyObject yield(ThreadContext context, IRubyObject[] args) {
-                            return yield(context, args[0]);
+                            return this.yield(context, args[0]);
                         }
 
                         @Override

--- a/src/main/java/org/jruby/rack/servlet/RequestCapture.java
+++ b/src/main/java/org/jruby/rack/servlet/RequestCapture.java
@@ -155,7 +155,7 @@ public class RequestCapture extends HttpServletRequestWrapper {
                     }
                     params.put(key, newValues);
                 }
-            } catch (UnsupportedEncodingException e) { /* UTF-8 should be fine */ }
+            } catch (UnsupportedEncodingException ignore) { /* UTF-8 should be fine */ }
         }
         
         this.requestParams = params;

--- a/src/main/java/org/jruby/rack/servlet/ResponseCapture.java
+++ b/src/main/java/org/jruby/rack/servlet/ResponseCapture.java
@@ -56,7 +56,7 @@ public class ResponseCapture extends HttpServletResponseWrapper {
 
     /**
      * Status code handler customizable by sub-classes.
-     *
+     * <p>
      * Besides serving as a setter, should return whether the status has been
      * "accepted" (super methods will be called when this is invoked from response
      * API methods such as {@link #setStatus(int)}).
@@ -253,10 +253,9 @@ public class ResponseCapture extends HttpServletResponseWrapper {
         return this.notHandledStatuses;
     }
 
-    @SuppressWarnings("unchecked")
     public void setNotHandledStatuses(final Collection<Integer> notHandledStatuses) {
         this.notHandledStatuses =
-            notHandledStatuses == null ? Collections.EMPTY_SET : notHandledStatuses;
+            notHandledStatuses == null ? Collections.emptySet() : notHandledStatuses;
     }
 
     boolean isHandledByDefault() {

--- a/src/main/java/org/jruby/rack/servlet/ServletRackEnvironment.java
+++ b/src/main/java/org/jruby/rack/servlet/ServletRackEnvironment.java
@@ -26,7 +26,6 @@ import org.jruby.rack.ext.Input;
  *
  * @author nicksieger
  */
-@SuppressWarnings("unchecked")
 public class ServletRackEnvironment extends HttpServletRequestWrapper
     implements RackEnvironment {
 
@@ -102,9 +101,9 @@ public class ServletRackEnvironment extends HttpServletRequestWrapper
 
         final StringBuilder buffer = new StringBuilder(32);
         final String onlyURI = getRequestURIWithoutQuery();
-        if ( onlyURI.length() > 0 ) {
+        if (!onlyURI.isEmpty()) {
             final String script = getScriptName();
-            if ( script != null && script.length() > 0
+            if ( script != null && !script.isEmpty()
                 && onlyURI.indexOf(script) == 0 ) {
                 buffer.append( onlyURI.substring(script.length()) );
             } else {


### PR DESCRIPTION
Backport of https://github.com/jruby/jruby-rack/pull/422 along with 
- the JRuby deprecation fixups from d6336323fdce4e885ee4665838c12c79eaa7c5cb (minus any generics signature changes)
- re-introducing Java 8 compatibility from c89f44c8c086cff02b8bdb70c872a7ecffae7111