### PR TITLE
[fix] avoid infinite loop in Response#isClientAbortException

### DIFF
--- a/src/main/java/org/jruby/rack/ext/Response.java
+++ b/src/main/java/org/jruby/rack/ext/Response.java
@@ -615,15 +615,23 @@ public class Response extends RubyObject implements RackResponse {
         return false;
     }
 
+    /**
+     * How many nested causes {@link #isClientAbortException(Exception)} inspects.
+     * A cause chain is allowed to be cyclic, thus the traversal needs a bound.
+     */
+    private static final int MAX_CAUSE_DEPTH = 20;
+
     // ioe.inspect =~ /(ClientAbortException|EofException|broken pipe)/i
     protected boolean isClientAbortException(final Exception ioe) {
         String error = ioe.toString();
         if ( error.contains("ClientAbortException") ) return true;
         if ( error.contains("EofException") ) return true;
-        while ( true ) {
+        Throwable cause = ioe;
+        for ( int depth = 0; depth < MAX_CAUSE_DEPTH; depth++ ) {
             if ( error.toLowerCase().contains("broken pipe") ) return true;
-            if ( ioe.getCause() == null ) break;
-            error = ioe.getCause().getMessage();
+            cause = cause.getCause();
+            if ( cause == null ) break;
+            error = cause.getMessage();
             if ( error == null ) break;
         }
         return false;

--- a/src/spec/ruby/jruby/rack/response_spec.rb
+++ b/src/spec/ruby/jruby/rack/response_spec.rb
@@ -519,6 +519,49 @@ describe JRuby::Rack::Response do
       end
     end
 
+    it "raises exceptions with a nested cause that do not look like abort exceptions" do
+      servlet_response = org.jruby.rack.mock.fail.FailingHttpServletResponse.new
+      # e.g. Jetty failing a stalled write: IOException caused by a TimeoutException
+      servlet_response.setFailure java.io.IOException.new(
+        java.util.concurrent.TimeoutException.new('Idle timeout expired: 30000/30000 ms')
+      )
+      begin
+        with_swallow_client_abort do
+          response.write_body new_response_environment(servlet_response)
+        end
+        fail 'IO exception NOT raised!'
+      rescue java.io.IOException => e
+        expect(e.to_s).to match(/idle timeout expired/i)
+      end
+    end
+
+    it "swallows client abort exceptions nested deeper in the cause chain" do
+      servlet_response = org.jruby.rack.mock.fail.FailingHttpServletResponse.new
+      servlet_response.setFailure java.io.IOException.new('write failed',
+        java.io.IOException.new('connection problem', java.io.IOException.new('Broken pipe'))
+      )
+      with_swallow_client_abort do
+        response.write_body new_response_environment(servlet_response)
+      end
+    end
+
+    it "raises (and does not hang) on a cyclic cause chain" do
+      failure = java.io.IOException.new 'write failed'
+      cause = java.io.IOException.new 'nested failure'
+      failure.initCause cause
+      cause.initCause failure
+      servlet_response = org.jruby.rack.mock.fail.FailingHttpServletResponse.new
+      servlet_response.setFailure failure
+      begin
+        with_swallow_client_abort do
+          response.write_body new_response_environment(servlet_response)
+        end
+        fail 'IO exception NOT raised!'
+      rescue java.io.IOException => e
+        expect(e.to_s).to match(/write failed/i)
+      end
+    end
+
     private
 
     def with_dechunk(dechunk = true)


### PR DESCRIPTION
## Related issue
Fixes #449.

## Summary 

`isClientAbortException` walks the exception cause chain but never advances it, so each iteration re-reads the same cause and re-assigns the same message. See more details in #449.

### The fix

Advance the chain via a separate `cause` variable, and bound the traversal.

The bound is necessary as a cause chain may be cyclic (`a.initCause(b); b.initCause(a)` is possible), which would still hang a `cause = cause.getCause()`.