### PR TITLE
build(deps): remove unnecessary rdoc restriction

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -17,8 +17,6 @@ version_spec = ->(prefix, desc) { "~> #{major_minor.call(prefix, desc)}.0" }
         c[:ext_gems]&.each do |gem_name|
           gem gem_name
         end
-
-        gem "rdoc", "!= 8.0.0" if major_minor.call("rails", rails_desc) >= "7.0"
       end
     end
   end

--- a/examples/rails7/Gemfile
+++ b/examples/rails7/Gemfile
@@ -5,7 +5,6 @@ ruby RUBY_VERSION
 gem 'rails', '~> 7.2.0'
 gem 'rack', '~> 2.2.0'
 gem 'sprockets-rails'
-gem 'rdoc', '!= 8.0.0' # Transitive of irb, broken on JRuby 10.x
 
 group :development do
   if !ENV['WARBLER_SRC']; gem 'warbler' else gem 'warbler', path: '../../../warbler' end

--- a/gemfiles/rails72_rack22.gemfile
+++ b/gemfiles/rails72_rack22.gemfile
@@ -5,7 +5,6 @@ source "https://rubygems.org"
 group :default do
   gem "rack", "~> 2.2.0"
   gem "rails", "~> 7.2.0"
-  gem "rdoc", "!= 8.0.0"
 end
 
 group :development do

--- a/gemfiles/rails80_rack22.gemfile
+++ b/gemfiles/rails80_rack22.gemfile
@@ -5,7 +5,6 @@ source "https://rubygems.org"
 group :default do
   gem "rack", "~> 2.2.0"
   gem "rails", "~> 8.0.0"
-  gem "rdoc", "!= 8.0.0"
 end
 
 group :development do


### PR DESCRIPTION
Shouldn't be needed now that rbs has been released.