### PR TITLE
test: add a Rack::Lint conformance spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - fix: JRuby::Rack::Input#read(0) should return an empty string
 - fix: close the original body when ShowStatus replaces it
 - fix: detect Transfer-Encoding/Content-Length headers case-insensitively
+- chore: revert `rack.version` value to be Rack 2.2 spec conformant
 
 ## 1.3.0 
 

--- a/src/main/ruby/rack/handler/servlet/default_env.rb
+++ b/src/main/ruby/rack/handler/servlet/default_env.rb
@@ -231,7 +231,7 @@ module Rack
 
         def load_builtin(env, key)
           case key
-          when 'rack.version'         then env[key] = ::Rack::RELEASE
+          when 'rack.version'         then env[key] = ::Rack::VERSION
           when 'rack.multithread'     then env[key] = true
           when 'rack.multiprocess'    then env[key] = false
           when 'rack.run_once'        then env[key] = false

--- a/src/spec/ruby/rack/handler/servlet_lint_spec.rb
+++ b/src/spec/ruby/rack/handler/servlet_lint_spec.rb
@@ -1,0 +1,75 @@
+#--
+# This source code is available under the MIT license.
+# See the file LICENSE.txt for details.
+#++
+
+require File.expand_path('../../spec_helper', File.dirname(__FILE__))
+
+require 'rack'
+require 'rack/lint'
+require 'uri'
+require 'rack/handler/servlet'
+
+# End-to-end conformance check: the env built from the servlet request and the
+# handling of the (Lint wrapped) response must satisfy the loaded Rack version's
+# SPEC - Rack::Lint raises when either side of the contract is broken.
+describe 'Rack::Handler::Servlet (Rack::Lint)' do
+
+  before :each do
+    @servlet_context = mock_servlet_context
+    allow(@rack_context).to receive(:getServerInfo).and_return 'Mock-Container/1.0'
+    @servlet_request = org.springframework.mock.web.MockHttpServletRequest.new(@servlet_context)
+    @servlet_response = org.springframework.mock.web.MockHttpServletResponse.new
+    @servlet_env = org.jruby.rack.servlet.ServletRackEnvironment.new(
+      @servlet_request, @servlet_response, @rack_context
+    )
+
+    @servlet_request.setMethod('GET')
+    @servlet_request.setContextPath('')
+    @servlet_request.setRequestURI('/some/path')
+    @servlet_request.setQueryString('a=1&b=2')
+    @servlet_request.addParameter('a', '1')
+    @servlet_request.addParameter('b', '2')
+    @servlet_request.setServerName('lint.example.com')
+    @servlet_request.setServerPort(8080)
+    @servlet_request.setProtocol('HTTP/1.1')
+    @servlet_request.setRemoteAddr('127.0.0.1')
+    @servlet_request.setContent(''.to_java_bytes)
+    @servlet_request.addHeader('Accept', 'text/plain')
+  end
+
+  let(:inner_app) do
+    lambda do |env|
+      env['rack.input'].read # exercises the Lint wrapped input contract
+      [ 200, { 'Content-Type' => 'text/plain', 'Content-Length' => '2' }, [ 'OK' ] ]
+    end
+  end
+
+  let(:servlet) { Rack::Handler::Servlet.new Rack::Lint.new(inner_app) }
+
+  shared_examples 'lint-compatible env' do
+
+    it "creates a SPEC compatible env and writes the response" do
+      response = servlet.call(@servlet_env)
+      expect(response.to_java.getStatus).to eql 200
+
+      response_env = org.jruby.rack.servlet.ServletRackResponseEnvironment.new(@servlet_response)
+      response.to_java.respond(response_env)
+      expect(@servlet_response.getStatus).to eql 200
+      expect(@servlet_response.getContentAsString).to eql 'OK'
+    end
+
+  end
+
+  describe 'with (default) env' do
+    it_behaves_like 'lint-compatible env'
+  end
+
+  describe 'with servlet env' do
+    before { Rack::Handler::Servlet.env = :servlet }
+    after { Rack::Handler::Servlet.env = nil }
+
+    it_behaves_like 'lint-compatible env'
+  end
+
+end

--- a/src/spec/ruby/rack/handler/servlet_spec.rb
+++ b/src/spec/ruby/rack/handler/servlet_spec.rb
@@ -44,10 +44,11 @@ describe Rack::Handler::Servlet do
 
     it "creates a hash with the Rack variables in it" do
       hash = servlet.create_env(@servlet_env)
-      expect(hash['rack.version']).to eq Rack::RELEASE
+      expect(hash['rack.version']).to eq Rack::VERSION
       expect(hash['rack.multithread']).to eq true
       expect(hash['rack.multiprocess']).to eq false
       expect(hash['rack.run_once']).to eq false
+      expect(hash['rack.hijack?']).to eq false
     end
 
     it "adds all attributes from the servlet request" do
@@ -204,7 +205,7 @@ describe Rack::Handler::Servlet do
       end
 
       env = servlet.create_env @servlet_env
-      expect(env["rack.version"]).to eq Rack::RELEASE
+      expect(env["rack.version"]).to eq Rack::VERSION
       expect(env["CONTENT_TYPE"]).to eq "text/html"
       expect(env["HTTP_HOST"]).to eq "serverhost"
       expect(env["HTTP_ACCEPT"]).to eq "text/*"


### PR DESCRIPTION
Runs a Lint wrapped app through Rack::Handler::Servlet (both DefaultEnv and ServletEnv modes) and writes the response back through the servlet response path, so env construction, rack.input behavior and body close handling are validated against the loaded Rack version's SPEC.

Also fixes the Rack 2.x arm's rack.version value to be Rack::VERSION (the protocol version Array the Rack 2 SPEC and Lint expect)